### PR TITLE
Tutorial 4: Characterising Benthic Biozones

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# DOI resolvers often block automated link checkers with 403
+https://doi.org/.*

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,9 @@ Config/Needs/website:
     patchwork,
     scales,
     skimr,
-    tmap
+    tmap,
+    leaflet,
+    htmlwidgets
 RoxygenNote: 7.3.2
 Depends: 
     R (>= 3.5)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,9 @@ Config/Needs/website:
     skimr,
     tmap,
     leaflet,
-    htmlwidgets
+    htmlwidgets,
+    downlit,
+    xml2
 RoxygenNote: 7.3.2
 Depends: 
     R (>= 3.5)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     yaml
 Remotes:
     EMODnet/emodnet.wfs,
-    EMODnet/emodnet.wcs
+    EMODnet/emodnet.wcs,
+    pepijn-devries/CopernicusMarine
 Config/Needs/website:
     CopernicusMarine,
     DT,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,11 +33,17 @@ Remotes:
     EMODnet/emodnet.wfs,
     EMODnet/emodnet.wcs
 Config/Needs/website:
+    CopernicusMarine,
     DT,
+    ggridges,
+    janitor,
     knitr,
     pkgload,
     purrr,
+    readr,
     rmarkdown,
+    stars,
+    stringr,
     tibble,
     tidyr,
     tidyterra,
@@ -45,6 +51,7 @@ Config/Needs/website:
     rnaturalearth,
     rnaturalearthdata,
     patchwork,
+    scales,
     skimr,
     tmap
 RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ URL: https://github.com/r-rse/emodnet-bio-r-geo-tutorials
 BugReports: https://github.com/r-rse/emodnet-bio-r-geo-tutorials/issues
 Imports:
     cli,
+    CopernicusMarine,
     emodnet.wfs,
     emodnet.wcs,
     pins,
@@ -34,7 +35,6 @@ Remotes:
     EMODnet/emodnet.wcs,
     pepijn-devries/CopernicusMarine
 Config/Needs/website:
-    CopernicusMarine,
     DT,
     ggridges,
     janitor,

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -32,7 +32,7 @@ website:
             href: tutorials/tutorial-02.qmd
           - text: "Tutorial 3: Biodiversity Change and Depth"
             href: tutorials/tutorial-03.qmd
-          - text: "Tutorial 4: Functional Traits Across Habitats"
+          - text: "Tutorial 4: Characterising Benthic Biozones"
             href: tutorials/tutorial-04.qmd
       - about.qmd
     right:

--- a/assets/images/oceanic-divisions.svg
+++ b/assets/images/oceanic-divisions.svg
@@ -1,1 +1,224 @@
-File not found: /v1/AUTH_mw/wikipedia-commons-local-public.cb/c/cb/Oceanic_divisions.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 11.0, SVG Export Plug-In . SVG Version: 6.0.0 Build 78)  -->
+<svg
+   xmlns:xap="http://ns.adobe.com/xap/1.0/"
+   xmlns:x="adobe:ns:meta/"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://web.resource.org/cc/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1113.944"
+   height="834.958"
+   viewBox="0 0 1113.944 834.958"
+   xml:space="preserve"
+   id="svg2"
+   version="1.1"
+   font-family="Bitstream Vera Sans, sans-serif"
+   font-size="18px">
+  
+  <sodipodi:namedview
+   inkscape:window-height="1000"
+   inkscape:window-width="1680"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   guidetolerance="10.0"
+   gridtolerance="10.0"
+   objecttolerance="10.0"
+   borderopacity="1.0"
+   bordercolor="#666666"
+   pagecolor="#ffffff"
+   id="base"
+   inkscape:zoom="0.96785369"
+   inkscape:cx="681.57844"
+   inkscape:cy="369.86923"
+   inkscape:window-x="-8"
+   inkscape:window-y="-8"
+   inkscape:current-layer="Layer_2"/>
+  
+	<metadata id="metadata4">
+    <x:xmpmeta x:xmptk="XMP toolkit 3.0-29, framework 1.6">
+      <metadata id="metadata640">
+        <rdf:RDF>
+          <rdf:Description rdf:about="">
+            <xap:CreateDate>2007-03-20T05:37:13Z</xap:CreateDate>
+            <xap:ModifyDate>2007-03-20T05:38:10Z</xap:ModifyDate>
+            <xap:CreatorTool>Illustrator</xap:CreatorTool>
+          </rdf:Description>
+
+          <rdf:Description rdf:about="">
+            <dc:format>image/svg+xml</dc:format>
+          </rdf:Description>
+
+          <cc:Work rdf:about="">
+            <dc:format>image/svg+xml</dc:format>
+            <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+          </cc:Work>
+        </rdf:RDF>
+      </metadata>
+    </x:xmpmeta>
+	</metadata>
+  
+  <defs id="defs638">
+    <marker id="arre" markerWidth="15" markerHeight="10" refX="15" refY="5" orient="auto">
+      <path d="M5,5 L0,0 L 15,5 L 0,10 L 5,5 Z" fill="black" stroke="none"/>
+    </marker>
+    <marker id="arrs" markerWidth="15" markerHeight="10" refX="0" refY="5" orient="auto">
+      <path d="M10,5 L15,0 L 0,5 L 15,10 L 10,5 Z" fill="black" stroke="none"/>
+    </marker>
+  </defs>
+  
+  <style type="text/css">
+    text {
+      fill:#000000;
+    }
+    text.depth {
+      fill:darkblue;
+      text-anchor:end;
+    }
+    text.temp {
+      fill:#000000;
+      text-anchor:end;
+    }
+    
+    .dim {
+      fill:none;
+      stroke:black;
+      stroke-width:1;
+      /* stroke-dasharray: 8 8; */
+    }
+    .dim2 {
+      fill:none;
+      stroke:black;
+      stroke-width:1;
+    }
+  </style>
+  
+	<g id="Layer_2">
+    
+    <!-- water/sky -->
+		<linearGradient id="XMLID_3_" gradientUnits="userSpaceOnUse" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0.0" style="stop-color:#FFFFFF" />
+			<stop offset="0.0056" style="stop-color:#FFFFFF" id="stop8" />
+			<stop offset="1" style="stop-color:#2A7BB6" id="stop10" />
+		</linearGradient>
+    <rect x="0" y="0" fill="url(#XMLID_3_)" width="100%" height="100%" id="rect12" />
+    
+    <!-- continent -->
+    <linearGradient id="XMLID_4_" gradientUnits="userSpaceOnUse" x1="460.2563" y1="156.4927" x2="460.2563" y2="777.4614">
+				<stop offset="0" style="stop-color:#E5DFBB" id="stop23" />
+				<stop offset="1" style="stop-color:#9C8014" id="stop25" />
+		</linearGradient>
+		<path fill="url(#XMLID_4_)" stroke="#000000" d="M0.5,84.496l93.054,26.999c0,0,35.999,29.999,98.995,46.498     s235.488,67.497,235.488,67.497s88.219,277.482,299.984,337.483c89.996,25.499,163.492,55.497,166.492,98.995     s25.499,172.491,25.499,172.491H0.5V84.496z" id="path27" />
+			
+    <!-- vertical line, high water -->
+    <line fill="none" stroke="#000000" stroke-dasharray="8 8" x1="93.941" y1="107.888" x2="93.941" y2="309.888" id="line129" />
+    <!-- vertical line, low water  -->
+    <line fill="none" stroke="#000000" stroke-dasharray="8 8" x1="138.941" y1="52.888" x2="138.941" y2="266.889" id="line127" />
+
+    <!--leader line, high water -->
+		<line fill="none" stroke="#000000" x1="85.941" y1="83.888" x2="93.554" y2="111.495" id="line111" />
+		<text x="58.275604" y="46.338581" id="text3763"><tspan id="tspan3765">High </tspan><tspan x="58.275604" y="68.838581" id="tspan3767">water</tspan></text>
+    
+    <!-- leader line, low water -->
+		<line fill="none" stroke="#000000" x1="139.941" y1="139.888" x2="160" y2="135" id="line175" />
+    <text x="165" y="140" id="text3781"><tspan id="tspan3783">Low water</tspan></text>
+    
+    <!-- water surface -->
+		<line fill="none" stroke="#0000FF" x1="97.941" y1="113.888" x2="1113.944" y2="113.888" id="line113" />
+			
+    <!-- 200 m line -->
+		<line fill="none" stroke="#000000" stroke-dasharray="2 8" x1="201.941" y1="158.888" x2="1102.941" y2="158.888" id="line14" />
+    <text class="depth" x="1040" y="180.93353" id="text3803"><tspan id="tspan3805">200 m</tspan></text>
+    
+    <!-- 10 degC 700 to 1000 m -->
+    <line fill="none" stroke="#000000" stroke-dasharray="2 8" x1="447.941" y1="276.888" x2="740" y2="276.888" id="line16" />
+		<line fill="none" stroke="#000000" stroke-dasharray="2 8" x1="800" y1="276.888" x2="1101.941" y2="276.888" id="line143" />
+    <text class="temp" x="790" y="283.1553" id="text3811"><tspan id="tspan3813">10 °C</tspan></text>
+    <text class="depth" x="1040" y="303.88602" id="text3819"><tspan id="tspan3821">700 to 1&#8201;000 m</tspan></text>
+    
+    <!-- 4 degC 2000 to 4000 m -->
+		<line fill="none" stroke="#000000" stroke-dasharray="2 8" x1="518.941" y1="403.888" x2="740" y2="403.888" id="line18" />
+		<line fill="none" stroke="#000000" stroke-dasharray="2 8" x1="800" y1="403.888" x2="1100.941" y2="403.888" id="line145" />
+    <text class="temp" x="790" y="410.30704" id="text3815"><tspan id="tspan3817">4 °C</tspan></text>
+    <text class="depth" x="1040" y="426.83847" id="text3827"><tspan id="tspan3829">2&#8201;000 to 4&#8201;000 m</tspan></text>
+			
+    <!-- 6000 m -->
+		<line fill="none" stroke="#000000" stroke-dasharray="2 8" x1="835.941" y1="600.888" x2="1101.941" y2="600.888" id="line20" />
+    <text class="depth" x="1040" y="625.21558" id="text3839"><tspan id="tspan3841">6&#8201;000 m</tspan></text>
+    
+    <!-- 10000 m -->
+    <text class="depth" x="1040" y="824.62585" id="text3883"><tspan id="tspan3885">10&#8201;000 m</tspan></text>
+     
+    <!-- Bathyal dimension -->
+    <path class="dim2" d="M471.902,376.764c7.056,12.909,14.555,24.604,22.132,33.215" id="path31" marker-end="url(#arre)"/>
+	  <path class="dim2" d="M429.537,276.486c0,0,3.892,11.862,10.374,28.875" id="path33" marker-start="url(#arrs)"/>
+    <text x="453.32559" y="-284.47137" id="text3879" transform="matrix(0.3818517,0.9242236,-0.9242236,0.3818517,0,0)"><tspan
+     id="tspan3881" x="453.32559" y="-284.47137">Bathyal</tspan></text>
+    
+    <!-- Abyssal dimension -->
+		<path class="dim2" d="M663.333,556.784c40.265,22.294,87.164,40.563,139.686,48.187" id="path53" marker-end="url(#arre)"/>
+		<path class="dim2" d="M501.534,417.479c0,0,28.44,39.52,79.821,82.638" id="path55" marker-start="url(#arrs)"/>
+    <text x="774.62537" y="95.508766" id="text3860" transform="matrix(0.8279969,0.5607327,-0.5607327,0.8279969,0,0)"><tspan
+     id="tspan3862" x="774.62537" y="95.508766">Abyssal</tspan></text>
+
+    <!-- Hadal dimension -->
+		<path class="dim2" d="M889.544,745.108 c4.378,37.395, 8.405,60, 10.97,78.851" id="path75" marker-end="url(#arre)" />
+		<path class="dim2" d="M818.018,609.469 c20,8, 58,20, 61.497,56.998" id="path77" marker-start="url(#arrs)" />
+    <text x="758.04437" y="-805.96875" id="text3847" transform="matrix(9.5347437e-2,0.9954441,-0.9954441,9.5347437e-2,0,0)"><tspan
+     id="tspan3849" x="758.04437" y="-805.96875">Hadal</tspan></text>
+
+    <!-- Benthic dimension -->
+    <path class="dim2" d="M487.434,525.34c99.499,111.548,188.507,111.548,188.507,111.548     s121-12,151,39s35,127,36,152" id="path91" marker-end="url(#arre)" />
+		<path class="dim2" d="M95.941,306.888 c100,0, 222,0, 340,151" id="path93" marker-start="url(#arrs)"/>
+    <text x="638.10748" y="-52.848846" id="text3875" transform="matrix(0.6175051,0.7865669,-0.7865669,0.6175051,0,0)"><tspan
+     id="tspan3877" x="638.10748" y="-52.848846">Benthic</tspan></text>
+    
+    <!-- Pelagic line -->
+    <line class="dim" x1="138.941" y1="52.888" x2="560.941" y2="52.888" id="line123" marker-start="url(#arrs)" />
+		<line class="dim" x1="637.941" y1="52.888" x2="1090.941" y2="52.888" id="line121" marker-end="url(#arre)" />
+    <text x="564.13489" y="57.981052" id="text3769"><tspan id="tspan3771">Pelagic</tspan></text>
+    
+    <!-- vertical line, neritic and oceanic -->
+    <line fill="none" stroke="#000000" stroke-dasharray="8 8" x1="428.941" y1="74.888" x2="428.941" y2="273.888" id="line125" />
+    <!-- oceanic and neritic -->
+		<line class="dim" x1="138.941" y1="92.138" x2="244.94" y2="92.138" id="line119" marker-start="url(#arrs)" />
+		<line class="dim" x1="314.941" y1="92.138" x2="428.941" y2="92.138" id="line117" marker-end="url(#arre)" />
+    <text x="249.07101" y="95.612122" id="text3773"><tspan id="tspan3775">Neritic</tspan></text>
+	  <line class="dim" x1="764.941" y1="92.138" x2="1090.941" y2="92.138" id="line115" marker-end="url(#arre)" />
+		<line class="dim" x1="428.941" y1="92.138" x2="675.941" y2="92.138" id="line117-7" marker-start="url(#arrs)" />
+    <text x="681.78839" y="96.711761" id="text3777"><tspan id="tspan3779">Oceanic</tspan></text>
+			
+    <!-- horizontal dimension line, Littoral -->
+    <line class="dim" x1="93.941" y1="200" x2="138.941" y2="200" id="line131" marker-start="url(#arrs)" marker-end="url(#arre)" />
+    <line class="dim" x1="138.941" y1="200" x2="160" y2="200" />
+    <text x="165" y="205" id="text3787"><tspan id="tspan3789">Littoral</tspan></text>
+    
+    <!-- horizontal dimension line, sublittoral or shelf -->
+    <line class="dim" x1="138.941" y1="249.887" x2="188.941" y2="249.887" id="line135" marker-start="url(#arrs)" />
+    <line class="dim" x1="360.941" y1="249.887" x2="426.941" y2="249.887" id="line133" marker-end="url(#arre)" />
+    <text x="189.01173" y="254.29172" id="text3791"><tspan id="tspan3793">Sublittoral or shelf</tspan></text>
+    
+    <!-- vertical dimension line, photic -->
+		<line fill="none" stroke="#000000" x1="1068.951" y1="114.888" x2="1068.951" y2="125.888" id="line141" marker-start="url(#arrs)" />
+    <line fill="none" stroke="#000000" x1="1068.951" y1="146.888" x2="1068.951" y2="158.888" id="line139" marker-end="url(#arre)" />
+    <text x="1068.951" y="141.73782" id="text3799" text-anchor="middle"><tspan id="tspan3801">Photic</tspan></text>
+    
+    <!-- vertical dimension line, Aphotic-->
+    <line fill="none" stroke="#000000" x1="1068.951" y1="158.888" x2="1068.951" y2="441.888" id="line139-8" marker-start="url(#arrs)" />
+    <line fill="none" stroke="#000000" x1="1068.951" y1="474.888" x2="1068.951" y2="829.888" id="line137" marker-end="url(#arre)" />
+    <text x="1068.951" y="464.03418" id="text3831" text-anchor="middle"><tspan id="tspan3833">Aphotic</tspan></text>
+    
+    <text x="1000" y="140.63818" id="text3795" text-anchor="end"><tspan id="tspan3797">Epipelagic</tspan></text>
+    <text x="1040" y="224.32852" id="text3807" text-anchor="end"><tspan id="tspan3809">Mesopelagic</tspan></text>
+    <text x="1040" y="350.38062" id="text3823" text-anchor="end"><tspan id="tspan3825">Bathypelagic</tspan></text>
+    <text x="1040" y="510.52881" id="text3835" text-anchor="end"><tspan id="tspan3837">Abyssalpelagic</tspan></text>
+    <text x="1040" y="703.73981" id="text3843" text-anchor="end"><tspan id="tspan3845">Hadalpelagic</tspan></text>
+    
+    <text style="font-size:56px;" x="92.989189" y="597.31873" id="text3887"><tspan
+     id="tspan3889">Oceanic</tspan><tspan
+     x="92.989189" y="667.31873" id="tspan3891">divisions</tspan></text>
+  </g>
+</svg>

--- a/assets/images/oceanic-divisions.svg
+++ b/assets/images/oceanic-divisions.svg
@@ -1,0 +1,1 @@
+File not found: /v1/AUTH_mw/wikipedia-commons-local-public.cb/c/cb/Oceanic_divisions.svg

--- a/concepts.qmd
+++ b/concepts.qmd
@@ -592,6 +592,20 @@ The [`terra` package](https://rspatial.github.io/terra/) is the modern replaceme
 
 **When to use:** Working with gridded data, environmental layers, or continuous surfaces.
 
+### stars - Spatiotemporal Arrays
+
+The [`stars` package](https://r-spatial.github.io/stars/) handles **multi-dimensional spatial data** (sometimes called datacubes). While `terra` works with 2D raster grids (and stacks of them), `stars` is designed for data with additional dimensions like time, depth, or wavelength — common in oceanographic and climate datasets.
+
+**Key features:**
+
+-   Represents data as multi-dimensional arrays with named dimensions (e.g., longitude, latitude, time, elevation)
+-   Supports both regular and rectilinear grids (where cell sizes vary along a dimension)
+-   Applies functions across specified dimensions (e.g., computing a time-series mean for each pixel)
+-   Resamples or regrids data onto a different grid structure
+-   Integrates with `sf` for spatial operations on the underlying geometry
+
+**When to use:** Working with multi-dimensional data such as oceanographic reanalysis products (temperature over time and depth), satellite time series, or any data served as datacubes. The `CopernicusMarine` package returns `stars` objects, which can be summarised and converted to `terra` rasters for further analysis.
+
 ## Understanding Spatial Data Objects in R
 
 Understanding how R represents spatial data internally helps you work more effectively with these packages and troubleshoot issues when they arise.
@@ -765,7 +779,16 @@ The tutorials demonstrate when and how to specify output formats to optimize you
 -   Multi-dimensional arrays
 -   Common for oceanographic and climate data
 -   Handles time series and multiple variables
--   Used by Copernicus Marine Service
+-   Traditional file-based format: you download the whole file before reading it
+
+**Zarr** (.zarr)
+
+-   Cloud-native, chunked array format for multi-dimensional data
+-   Designed for efficient remote access: clients can read spatial or temporal subsets without downloading the entire dataset
+-   Increasingly used by ocean data providers including the Copernicus Marine Service, which stores data in both NetCDF and zarr formats
+-   Stores arrays alongside metadata (dimensions, units, coordinate reference systems) in a directory or object-store structure
+-   The `CopernicusMarine` R package uses zarr stores for efficient spatial/temporal subsetting via `cms_download_subset()`, returning data as `stars` objects
+-   Copernicus Marine discovers and describes datasets through a [STAC](https://stacspec.org/) catalogue. Layer-level metadata uses the [STAC datacube extension](https://github.com/stac-extensions/datacube) to describe dimensions and variables, with additional Copernicus-specific fields for variable names, units, and visualisation hints
 
 ## Glossary of Common Terms
 
@@ -800,9 +823,12 @@ glossary <- tibble::tribble(
   "Raster"                            , "Gridded spatial data where each cell contains a value."                                                                                                                                                                                     ,
   "Resolution"                        , "The size of raster cells (e.g., 100m × 100m); smaller cells = finer detail."                                                                                                                                                               ,
   "Spatial join"                      , "Combining features from different layers based on spatial relationships."                                                                                                                                                                   ,
+  "STAC (SpatioTemporal Asset Catalog)", "A specification for describing geospatial datasets through standardised metadata catalogues. Used by Copernicus Marine Service to organise and discover data products, layers, and variables."                                                  ,
+  "stars object"                      , "An R object from the stars package representing multi-dimensional spatial data (datacubes) with named dimensions such as longitude, latitude, time, and depth."                                                                             ,
   "Vector"                            , "Spatial data representing discrete features as points, lines, or polygons."                                                                                                                                                                 ,
   "WCS (Web Coverage Service)"        , "A standard protocol for serving raster data."                                                                                                                                                                                               ,
-  "WFS (Web Feature Service)"         , "A standard protocol for serving vector data."
+  "WFS (Web Feature Service)"         , "A standard protocol for serving vector data."                                                                                                                                                                                               ,
+  "Zarr"                              , "A cloud-native, chunked array format for multi-dimensional data. Designed for efficient remote subsetting so clients can read only the data they need without downloading entire files."
 )
 
 knitr::kable(glossary, col.names = c("Term", "Definition")) |>
@@ -824,6 +850,12 @@ knitr::kable(glossary, col.names = c("Term", "Definition")) |>
 -   [**terra Package Reference**](https://rspatial.github.io/terra/reference/terra-package.html) - Complete function reference for raster operations
 -   [**emodnet.wfs Documentation**](https://github.com/EMODnet/emodnet.wfs) - Guide to accessing EMODnet WFS services
 -   [**emodnet.wcs Documentation**](https://github.com/EMODnet/emodnet.wcs) - Guide to accessing EMODnet WCS services
+
+### Standards and Specifications
+
+-   [**STAC Specification**](https://stacspec.org/) - The SpatioTemporal Asset Catalog standard for describing geospatial datasets
+-   [**STAC Intro Tutorial**](https://stacspec.org/en/tutorials/intro-to-stac/) - Beginner-friendly introduction to STAC concepts
+-   [**STAC Datacube Extension**](https://github.com/stac-extensions/datacube) - Extension defining how datacube dimensions and variables are described in STAC metadata
 
 ### Additional Resources
 

--- a/concepts.qmd
+++ b/concepts.qmd
@@ -783,7 +783,7 @@ The tutorials demonstrate when and how to specify output formats to optimize you
 
 **Zarr** (.zarr)
 
--   Cloud-native, chunked array format for multi-dimensional data
+-   Cloud-native, chunked (often compressed) array format for multi-dimensional data
 -   Designed for efficient remote access: clients can read spatial or temporal subsets without downloading the entire dataset
 -   Increasingly used by ocean data providers including the Copernicus Marine Service, which stores data in both NetCDF and zarr formats
 -   Stores arrays alongside metadata (dimensions, units, coordinate reference systems) in a directory or object-store structure

--- a/index.qmd
+++ b/index.qmd
@@ -8,7 +8,7 @@ Learn how to access and analyze marine biological and environmental data from [E
 
 Whether you're investigating marine protected areas, exploring species distributions, or analyzing biodiversity change, these tutorials provide reproducible code and practical examples you can adapt to your own research questions.
 
-::: {.callout-tip}
+::: callout-tip
 ## New to geospatial analysis?
 
 If you're unfamiliar with spatial data concepts, coordinate systems, or the difference between vector and raster data, start with our [**Geospatial Concepts**](concepts.qmd) page.
@@ -108,7 +108,7 @@ To get the most from these tutorials, you should have:
 -   Awareness of vector vs. raster data
 -   Familiarity with common spatial operations
 
-::: {.callout-note}
+::: callout-note
 If you're new to geospatial analysis, visit our [**Geospatial Concepts**](concepts.qmd) page for an introduction to key concepts before starting the tutorials.
 :::
 
@@ -124,16 +124,19 @@ Install the required packages using the following code:
 
 # Install packages from CRAN
 install.packages(c(
-    "emodnet.wfs",
-    "sf",
-    "terra",
-    "dplyr",
-    "ggplot2",
-    "tmap"
+  "emodnet.wfs",
+  "sf",
+  "terra",
+  "dplyr",
+  "ggplot2",
+  "tmap"
 ))
 
 # Install emodnet.wcs' latest version (not yet on CRAN)
-install.packages('emodnet.wcs', repos = c('https://emodnet.r-universe.dev', 'https://cloud.r-project.org'))
+install.packages(
+  'emodnet.wcs',
+  repos = c('https://emodnet.r-universe.dev', 'https://cloud.r-project.org')
+)
 ```
 
 ### Quick Start
@@ -168,3 +171,4 @@ install.packages('emodnet.wcs', repos = c('https://emodnet.r-universe.dev', 'htt
 ## About This Project
 
 These tutorials are part of the [EMODnet Biology](https://emodnet.ec.europa.eu/en/biology) initiative. Learn more about the project, contributors, and funding on the [About](about.qmd) page.
+

--- a/tutorials/references.bib
+++ b/tutorials/references.bib
@@ -57,12 +57,11 @@
   doi = {10.3389/fmars.2022.767290}
 }
 
-@article{mccallum2025,
-  author = {McCallum, Aaron W. and McClain, Craig R. and Giribet, Gonzalo and others},
-  title = {The Marine Organism Body Size database: A unified resource for body size data across marine taxa},
+@article{mcclain2025,
+  author = {McClain, C. R. and Heim, N. A. and Knope, M. L. and Monarrez, P. M. and Payne, J. L. and Santos, I. T. and Webb, T. J.},
+  title = {{MOBS} 1.0: A Database of Interspecific Variation in Marine Organismal Body Sizes},
   journal = {Global Ecology and Biogeography},
   volume = {34},
-  number = {3},
   pages = {e70062},
   year = {2025},
   doi = {10.1111/geb.70062}

--- a/tutorials/references.bib
+++ b/tutorials/references.bib
@@ -56,3 +56,14 @@
   year = {2022},
   doi = {10.3389/fmars.2022.767290}
 }
+
+@article{mccallum2025,
+  author = {McCallum, Aaron W. and McClain, Craig R. and Giribet, Gonzalo and others},
+  title = {The Marine Organism Body Size database: A unified resource for body size data across marine taxa},
+  journal = {Global Ecology and Biogeography},
+  volume = {34},
+  number = {3},
+  pages = {e70062},
+  year = {2025},
+  doi = {10.1111/geb.70062}
+}

--- a/tutorials/tutorial-01.qmd
+++ b/tutorials/tutorial-01.qmd
@@ -14,7 +14,7 @@ format:
 
 ## Introduction
 
-The North Sea is one of Europe's most heavily industrialised marine regions. Beneath its waters lies a dense network of energy infrastructure, including oil and gas platforms, pipelines, and offshore wind installations, alongside a growing network of marine protected areas (MPAs) established under EU directives such as the [Marine Strategy Framework Directive](https://environment.ec.europa.eu/topics/marine-environment/marine-strategy-framework-directive_en) and the [Habitats Directive](https://environment.ec.europa.eu/topics/nature-and-biodiversity/habitats-directive_en).
+The North Sea is one of Europe's most heavily industrialised marine regions. Beneath its waters lies a dense network of energy infrastructure, including oil and gas platforms, pipelines, and offshore wind installations, alongside a growing network of marine protected areas (MPAs) established under EU directives such as the [Marine Strategy Framework Directive](https://environment.ec.europa.eu/topics/marine-environment_en) and the [Habitats Directive](https://environment.ec.europa.eu/topics/nature-and-biodiversity/habitats-directive_en).
 
 Understanding where these features intersect is crucial for:
 

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -16,7 +16,7 @@ format:
 
 ## Introduction
 
-The Gulf of Lion, located in the northwestern Mediterranean off the coast of southern France, hosts a rich diversity of benthic communities shaped by the Rhône River delta, diverse substrates from sandy beaches to deep canyons, and strong environmental gradients. Characterising the biozones of this region, from the sunlit infralittoral to the deep bathyal, requires bringing together habitat maps, environmental data, species occurrences, and functional traits such as body size.
+The [Gulf of Lion](https://en.wikipedia.org/wiki/Gulf_of_Lion), located in the northwestern Mediterranean off the coast of southern France, hosts a rich diversity of benthic communities shaped by the Rhône River delta, diverse substrates from sandy beaches to deep canyons, and strong environmental gradients. Characterising the biozones of this region, from the sunlit infralittoral to the deep bathyal, requires bringing together habitat maps, environmental data, species occurrences, and functional traits such as body size.
 
 In this tutorial, we demonstrate how to **integrate multiple EU marine data infrastructures** to characterise benthic biozones in the Gulf of Lion. We combine:
 
@@ -81,19 +81,24 @@ This tutorial uses a broader set of packages than previous tutorials, reflecting
 ```{r}
 #| label: load-packages
 #| message: false
+# Data access
 library(emodnet.wfs)
 library(emodnet.wcs)
 library(CopernicusMarine)
+# Spatial data wrangling
 library(terra)
 library(sf)
+# Data wrangling
 library(dplyr)
 library(tidyr)
 library(purrr)
 library(stringr)
+# Data visualization
 library(ggplot2)
 library(ggridges)
 library(patchwork)
 library(tidyterra)
+# Interactive maps
 library(leaflet)
 library(htmlwidgets)
 
@@ -120,6 +125,7 @@ install.packages(c(
 ))
 ```
 
+<!-- TODO: update once emodnet.wcs is available from CRAN -->
 The `emodnet.wcs` package is not yet on CRAN; install the development version from GitHub:
 
 ``` r
@@ -132,7 +138,7 @@ pak::pak("EMODnet/emodnet.wcs")
 
 We focus on the Gulf of Lion in the northwestern Mediterranean. This region offers good coverage across most data sources involved, with diverse substrate types (sand, mud, coarse sediments, seagrass meadows) and spatial sampling across 165 unique locations. The Gulf of Lion also spans multiple biozones from infralittoral to bathyal depths.
 
-We start by defining a bounding box for our study area in WGS 84 (longitude/latitude degrees), which we will use to filter data downloads to this region. We also create an EPSG:3035 version, an equal-area projection that several of our data sources use (we discuss this CRS in more detail in the [spatial data integration](#spatial-data-integration) section):
+We start by defining a bounding box for our study area in WGS 84 (longitude/latitude degrees), chosen to cover the continental shelf and slope of the Gulf of Lion from roughly Nice to Perpignan. We will use this to filter data downloads to this region. We also create an EPSG:3035 (ETRS89-extended / LAEA Europe) version, an equal-area projection that several of our data sources use (we discuss this CRS in more detail in the [spatial data integration](#spatial-data-integration) section):
 
 ```{r}
 #| label: define-study-area-bbox
@@ -215,6 +221,7 @@ Let's examine the attribute structure of the habitat layer:
 ```{r}
 #| label: inspect-habitat-attributes
 #| cache: true
+#| rows.print: 11
 habitat_attrs <- layer_attribute_descriptions(
   wfs = habitat_wfs,
   layer = "eusm2025_eunis2019_full"
@@ -225,7 +232,7 @@ habitat_attrs
 
 Key attributes include:
 
--   **`geom`**: Geometry column. WFS layers can use different names for this column, so we extract it programmatically below to construct CQL bounding box filters
+-   **`geom`**: Geometry column (the only row with `geometry = TRUE`). WFS layers can use different names for this column, so we extract it programmatically below to construct CQL bounding box filters
 -   **`eunis2019c`**: EUNIS 2019 habitat classification (level 3)
 -   **`eunis2019d`**: Human-readable EUNIS 2019 habitat description
 -   **`substrate`**: Seabed substrate type
@@ -390,14 +397,14 @@ We can confirm the CQL filter worked by checking the unique `eunis2019c` values 
 sort(unique(seabed_habitats$eunis2019c))
 ```
 
-All clean EUNIS codes, with no `"Na"` or `"or"` values. Let's see which habitat types are most common in our study area:
+All clean EUNIS codes, with no `"Na"` or `"or"` values. Let's see which habitat types are most common in our study area, using the human-readable `eunis2019d` descriptions:
 
 ```{r}
 #| label: habitat-type-summary
 # Summarise habitat types present
 seabed_habitats |>
   st_drop_geometry() |>
-  count(eunis2019c, sort = TRUE) |>
+  count(eunis2019d, sort = TRUE) |>
   head(10)
 ```
 
@@ -428,7 +435,7 @@ ggplot() +
       study_bbox_3035["ymax"]
     )
   ) +
-  scale_fill_viridis_d(option = "turbo", name = NULL) +
+  scale_fill_viridis_d(option = "turbo", direction = -1, name = NULL) +
   labs(title = "Seabed Habitats (EUNIS 2019)") +
   theme_minimal() +
   theme(
@@ -447,7 +454,7 @@ Next, we retrieve benthic species occurrence records from EMODnet Biology. These
 ::: {.callout-tip collapse="true"}
 ## Taxonomic matching with the `worrms` package
 
-The data we use here are already matched to WoRMS, but if you need to match your own species lists to the WoRMS taxonomic backbone, the [`worrms`](https://cran.r-project.org/package=worrms) R package provides a programmatic interface to WoRMS. It supports fuzzy name matching, retrieval of accepted names and synonyms, and lookup of taxonomic hierarchies, useful for standardising species names across datasets.
+The data we use here are already matched to WoRMS, but if you need to match your own species lists to the WoRMS taxonomic backbone, the [`worrms`](https://docs.ropensci.org/worrms/) R package provides a programmatic interface to WoRMS. It supports fuzzy name matching, retrieval of accepted names and synonyms, and lookup of taxonomic hierarchies, useful for standardising species names across datasets.
 :::
 
 ### Connecting to EMODnet Biology WFS
@@ -928,7 +935,7 @@ bottom_temp_mean <- bottom_temp_sampled |>
 
 The rest of our analysis uses `terra` for raster operations (zonal statistics, extraction). To convert from `stars` to a `terra` `SpatRaster`, we need to address a grid compatibility issue: the Copernicus Marine grid is **rectilinear** (cell spacing along longitude and latitude is not perfectly uniform), but `terra::rast()` requires a **regular** grid with uniform cell sizes.
 
-`st_warp()` resamples a `stars` object onto a target grid. We build that target with `st_as_stars()`, passing `st_bbox(bottom_temp_mean)` to preserve the original spatial extent and setting `dx` and `dy` to 1/24° to match the native Copernicus Marine resolution (~4.2 km at this latitude):
+`stars::st_warp()` resamples a `stars` object onto a target grid. We build that target with `stars::st_as_stars()`, passing `sf::st_bbox(bottom_temp_mean)` to preserve the original spatial extent and setting `dx` and `dy` to 1/24° to match the native Copernicus Marine resolution (~4.2 km at this latitude):
 
 ```{r}
 #| label: convert-to-terra
@@ -1176,7 +1183,7 @@ Although the occurrence data already contains pre-matched EUNIS codes, we use a 
 
 We perform spatial joins with `sf::st_join()` which works differently from a standard `dplyr` join: instead of matching values in columns, it matches on **geometry**. For each point in the left dataset (occurrences), `st_join()` finds which polygon in the right dataset (habitat polygons) contains that point, and appends that polygon's attributes. The default spatial predicate is `st_intersects`, meaning a point is matched to any polygon it touches or falls inside. This is the spatial equivalent of `left_join()`: all rows from the left dataset are kept, and unmatched rows get `NA` for the joined columns. Because both datasets are in EPSG:3035, the spatial join uses planar geometry directly (no geographic coordinate warnings).
 
-We `select()` only `substrate` and `biozone` from the habitat polygons before joining, so only those columns are appended. Finally, we filter out any occurrences without a biozone value, keeping only records we can assign to a biozone for our characterisation:
+We `select()` only `substrate` and `biozone` from the habitat polygons before joining, so only those columns are appended. Finally, we filter out any occurrences without a biozone value (these fall outside habitat polygon coverage, e.g. in areas excluded by our CQL filter or gaps in the seabed map), keeping only records we can assign to a biozone for our characterisation:
 
 ```{r}
 #| label: join-occurrences-habitats-traits
@@ -1207,6 +1214,8 @@ benthos_joined |>
 
 Biozones represent the vertical zonation of the seabed, from the sunlit infralittoral through the circalittoral to the deep bathyal and abyssal zones. This depth gradient is the primary ecological axis structuring benthic communities, influencing light availability, temperature, pressure, and food supply. The EUSeaMap habitat layer encodes biozone alongside habitat type and substrate for each polygon, giving us a natural framework to bring together all our data sources.
 
+![Profile view of oceanic divisions showing both pelagic (water column) and benthic (seafloor) zonation. The benthic zones (labelled along the seafloor) correspond to the biozones used in our analysis. Source: [K. Aainsqatsi / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Oceanic_divisions.svg), public domain.](/assets/images/oceanic-divisions.svg){#fig-oceanic-divisions}
+
 ### Habitat Composition by Biozone
 
 Different EUNIS habitat types are distributed across biozones. Using the full set of habitat polygons in the study area, this stacked bar chart shows which habitat types occur in each zone:
@@ -1226,7 +1235,7 @@ ggplot(
   aes(x = biozone, y = n, fill = str_wrap(eunis2019d, width = 50))
 ) +
   geom_bar(stat = "identity", position = "fill") +
-  scale_fill_viridis_d(option = "turbo", name = NULL) +
+  scale_fill_viridis_d(option = "turbo", direction = -1, name = NULL) +
   scale_y_continuous(labels = scales::percent) +
   labs(x = "Biozone", y = "Proportion of polygons") +
   theme_minimal() +

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -829,9 +829,10 @@ time_dim <- temp_yearly$properties[[1]]$`cube:dimensions`$time
 # Temporal extent (start and end dates)
 cat("Temporal extent:", time_dim$extent[[1]], "to", time_dim$extent[[2]])
 cat("Total time steps:", length(time_dim$values))
+cat("First 3 steps:", unlist(head(time_dim$values, 3)))
 ```
 
-The layer spans from 1987 to the present with yearly time steps. We now have all four pieces of information needed to download: the **product** ID (`MEDSEA_MULTIYEAR_PHY_006_004`), the **layer** ID (yearly means, `cmems_mod_med_phy-tem_my_4.2km_P1Y-m`), the **variable** ID (`bottomT`), and the available **time range**.
+The layer spans from 1987 to the present with yearly time steps indexed to January 1st of each year. We now have all four pieces of information needed to download: the **product** ID (`MEDSEA_MULTIYEAR_PHY_006_004`), the **layer** ID (yearly means, `cmems_mod_med_phy-tem_my_4.2km_P1Y-m`), the **variable** ID (`bottomT`), and the available **time range**.
 
 ### Choosing a Time Period
 
@@ -855,7 +856,7 @@ Sampling is concentrated in two periods: a large 1998 campaign and a main cluste
 
 ### Downloading Bottom Temperature
 
-`cms_download_subset()` returns a [`stars`](../concepts.qmd#stars---spatiotemporal-arrays) object (a multi-dimensional array):
+`cms_download_subset()` returns a [`stars`](../concepts.qmd#stars---spatiotemporal-arrays) object (a multi-dimensional array). Note that the `timerange` dates must match the layer's time steps, which as we saw above are indexed to January 1st of each year:
 
 ```{r}
 #| label: download-bottom-temperature
@@ -864,7 +865,7 @@ bottom_temp_stars <- cms_download_subset(
   layer = "cmems_mod_med_phy-tem_my_4.2km_P1Y-m",
   variable = "bottomT",
   region = study_bbox,
-  timerange = c("1998-01-01", "2018-12-31")
+  timerange = c("1998-01-01", "2018-01-01")
 )
 ```
 

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -193,7 +193,7 @@ habitat_wfs <- emodnet_init_wfs_client(
 
 ### Exploring Habitat Layers
 
-We need habitat polygons from the [EUSeaMap](https://emodnet.ec.europa.eu/en/euseamap), the broad-scale predictive habitat map for European seas. The service contains many layers, so we filter by title to find the EUSeaMap products:
+We need habitat polygons from the [EUSeaMap](https://emodnet.ec.europa.eu/en/seabed-habitats), the broad-scale predictive habitat map for European seas. The service contains many layers, so we filter by title to find the EUSeaMap products:
 
 ```{r}
 #| label: explore-habitat-layers

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -70,7 +70,7 @@ By the end of this tutorial, you will be able to:
 | Source | Description |
 |----------------------------|--------------------------------------------|
 | [Copernicus Marine Service](https://marine.copernicus.eu/) | Bottom temperature from [MEDSEA_MULTIYEAR_PHY_006_004](https://data.marine.copernicus.eu/product/MEDSEA_MULTIYEAR_PHY_006_004/description) reanalysis |
-| [MOBS Database](https://github.com/crmcclain/MOBS_OPEN) | Marine Organism Body Size database [@mccallum2025] |
+| [MOBS Database](https://github.com/crmcclain/MOBS_OPEN) | Marine Organism Body Size database [@mcclain2025] |
 
 ## Setup
 
@@ -979,7 +979,7 @@ The Marine Organism Body Size (MOBS) database provides body size measurements fo
 
 ### About MOBS
 
-The MOBS database [@mccallum2025] compiles body size measurements (length, diameter/width, height) from literature sources for marine species, linked via WoRMS AphiaIDs. This makes it ideal for linking to occurrence data like ours.
+The MOBS database [@mcclain2025] compiles body size measurements (length, diameter/width, height) from literature sources for marine species, linked via WoRMS AphiaIDs. This makes it ideal for linking to occurrence data like ours.
 
 ### Loading MOBS Data
 

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -1,11 +1,11 @@
 ---
-title: "4: Functional Traits Across Seabed Habitats"
-subtitle: "Integrating EMODnet Data with Trait and Environmental Data Sources in the Gulf of Lion"
+title: "4: Characterising Benthic Biozones"
+subtitle: "Combining Species Occurrences, Habitat Maps, Bathymetry, Temperature, and Body Size Data in the Gulf of Lion"
 difficulty: "Advanced"
 time: "~90 minutes"
 data-type: "WFS + WCS + External sources"
-description: "Learn to integrate EMODnet WFS and WCS services with external data sources including the Copernicus Marine Service and trait databases. Investigate how benthic species body size varies across seabed habitat types and environmental gradients in the Gulf of Lion."
-datasets: "Benthic species occurrences, seabed habitat polygons, bathymetry, bottom temperature, body size traits"
+description: "Learn to integrate EMODnet WFS and WCS services with external data sources including the Copernicus Marine Service and trait databases. Characterise benthic biozones in the Gulf of Lion using habitat composition, substrate type, environmental conditions, and body size distributions."
+datasets: "Seabed habitat polygons, benthic species occurrences, bathymetry, bottom temperature, body size data"
 df-print: paged
 bibliography: references.bib
 format:
@@ -16,58 +16,58 @@ format:
 
 ## Introduction
 
-The Gulf of Lion, located in the northwestern Mediterranean off the coast of southern France, hosts a rich diversity of benthic communities shaped by the Rhône River delta, diverse substrates from sandy beaches to deep canyons, and strong environmental gradients. Understanding how functional traits like body size vary across these habitats can reveal patterns of community assembly and environmental filtering that underpin ecosystem function.
+The Gulf of Lion, located in the northwestern Mediterranean off the coast of southern France, hosts a rich diversity of benthic communities shaped by the Rhône River delta, diverse substrates from sandy beaches to deep canyons, and strong environmental gradients. Characterising the biozones of this region, from the sunlit infralittoral to the deep bathyal, requires bringing together habitat maps, environmental data, species occurrences, and functional traits such as body size.
 
-In this tutorial, we demonstrate how to **integrate multiple EU marine data infrastructures** to explore trait-environment relationships in benthic communities. We combine:
+In this tutorial, we demonstrate how to **integrate multiple EU marine data infrastructures** to characterise benthic biozones in the Gulf of Lion. We combine:
 
-- **EMODnet WFS** for species occurrence records and habitat maps
-- **EMODnet WCS** for bathymetry data
-- **Copernicus Marine Service** for bottom temperature
-- **MOBS database** for species body size traits
+-   **EMODnet WFS** for habitat maps and species occurrence records
+-   **EMODnet WCS** for bathymetry data
+-   **Copernicus Marine Service** for bottom temperature
+-   **MOBS database** for species body size data
 
 This multi-source approach reflects real-world marine ecological analysis, where insights emerge from combining data across platforms and domains.
 
-### Why Body Size?
+### Why Include Body Size?
 
-Body size is a fundamental trait linked to metabolism, feeding strategy, life history, and ecological role. Larger organisms generally have lower mass-specific metabolic rates, longer lifespans, and different trophic positions than smaller organisms. The distribution of body sizes in a community can reveal patterns of:
+Body size is a fundamental trait linked to metabolism, feeding strategy, life history, and ecological role. Adding body size to a biozone characterisation enriches the picture beyond habitat composition and physical conditions. The distribution of body sizes across biozones can reveal:
 
-- **Environmental filtering**: Temperature and depth gradients may favour certain body size ranges
-- **Habitat associations**: Different seabed types may support communities with distinct size structures
-- **Community function**: Body size distributions affect energy flow and ecosystem processes
+-   **Environmental filtering**: Temperature and depth gradients may favour certain body size ranges
+-   **Habitat associations**: Different seabed types may support communities with distinct size structures
+-   **Community function**: Body size distributions affect energy flow and ecosystem processes
 
 ### Learning Objectives
 
 By the end of this tutorial, you will be able to:
 
-- Access benthic species occurrence data from EMODnet Biology WFS
-- Retrieve seabed habitat polygons from EMODnet Seabed Habitats WFS
-- Download bathymetry rasters from EMODnet Bathymetry WCS
-- Access bottom temperature data from the Copernicus Marine Service
-- Link species records to body size traits from external databases
-- Perform spatial joins between points and polygons
-- Extract raster values to point locations
-- Visualise trait-environment relationships across habitat types
+-   Retrieve seabed habitat polygons from EMODnet Seabed Habitats WFS
+-   Access benthic species occurrence data from EMODnet Biology WFS
+-   Download bathymetry rasters from EMODnet Bathymetry WCS
+-   Access bottom temperature data from the Copernicus Marine Service
+-   Link species records to body size data from external databases
+-   Join datasets using shared identifiers (EUNIS codes, AphiaIDs)
+-   Extract zonal statistics from rasters using habitat polygons
+-   Characterise benthic biozones using habitat, environmental, and trait data
 
 ### Data Sources
 
 **EMODnet WFS (Vector Data):**
 
 | Layer | Service | Description |
-|-------|---------|-------------|
+|------------------|----------------------|--------------------------------|
+| `eusm2025_eunis2019_full` | seabed_habitats_general_datasets_and_products | EU Seabed Map with EUNIS 2019 classification |
 | `eb185_benthos_full_matched` | biology | Benthic species occurrence records from European seas |
-| `eusm_2023_eunis2019_full` | seabed_habitats_general_datasets_and_products | EU Seabed Map with EUNIS 2019 classification |
 
 **EMODnet WCS (Raster Data):**
 
-| Coverage | Service | Description |
-|----------|---------|-------------|
-| `emodnet__mean_2020` | bathymetry | Mean water depth (bathymetry) |
+| Coverage             | Service    | Description                   |
+|----------------------|------------|-------------------------------|
+| `emodnet__mean_2022` | bathymetry | Mean water depth (bathymetry) |
 
 **External Sources:**
 
 | Source | Description |
-|--------|-------------|
-| [Copernicus Marine Service](https://marine.copernicus.eu/) | Bottom temperature from GLOBAL_MULTIYEAR_PHY_001_030 reanalysis |
+|----------------------------|--------------------------------------------|
+| [Copernicus Marine Service](https://marine.copernicus.eu/) | Bottom temperature from [MEDSEA_MULTIYEAR_PHY_006_004](https://data.marine.copernicus.eu/product/MEDSEA_MULTIYEAR_PHY_006_004/description) reanalysis |
 | [MOBS Database](https://github.com/crmcclain/MOBS_OPEN) | Marine Organism Body Size database [@mccallum2025] |
 
 ## Setup
@@ -87,24 +87,17 @@ library(sf)
 library(dplyr)
 library(tidyr)
 library(purrr)
+library(stringr)
 library(ggplot2)
+library(ggridges)
 library(patchwork)
 library(tidyterra)
 library(tmap)
 ```
 
 ```{r}
-#| label: setup
+#| label: load-internal-packages
 #| include: false
-# Set PROJ path if needed (for coordinate transformations)
-if (
-  Sys.getenv("PROJ_LIB") == "" &&
-    file.exists("/opt/homebrew/share/proj/proj.db")
-) {
-  Sys.setenv(PROJ_LIB = "/opt/homebrew/share/proj")
-}
-
-# Load package data and helper functions
 library(emodnet.bio.r.geo.tutorials)
 ```
 
@@ -113,45 +106,40 @@ library(emodnet.bio.r.geo.tutorials)
 
 Most packages are available from CRAN:
 
-```r
+``` r
 install.packages(c(
-  "terra", "sf", "dplyr", "tidyr", "purrr",
-  "ggplot2", "tidyterra", "tmap", "rnaturalearth"
+  "emodnet.wfs", "CopernicusMarine", "terra", "sf", "stars",
+  "dplyr", "tidyr", "purrr", "readr", "stringr", "ggplot2",
+  "ggridges", "janitor", "patchwork", "tidyterra", "tmap",
+  "rnaturalearth"
 ))
 ```
 
-For the EMODnet packages (development versions from GitHub):
+The `emodnet.wcs` package is not yet on CRAN; install the development version from GitHub:
 
-```r
+``` r
 # install.packages("pak")
-pak::pak(c("EMODnet/emodnet.wfs", "EMODnet/emodnet.wcs"))
+pak::pak("EMODnet/emodnet.wcs")
 ```
-
-For the Copernicus Marine Service package:
-
-```r
-pak::pak("pepijn-devries/CopernicusMarine")
-```
-
-**Note:** The CopernicusMarine package requires you to register for a free account at [marine.copernicus.eu](https://marine.copernicus.eu/) and configure your credentials. See the [package documentation](https://pepijn-devries.github.io/CopernicusMarine/) for setup instructions.
 :::
 
 ### Study Area
 
-We focus on the Gulf of Lion in the northwestern Mediterranean. This region offers excellent data coverage with diverse substrate types (sand, mud, coarse sediments, seagrass meadows) and good spatial sampling across 165 unique locations. The Gulf of Lion also spans multiple biozones from infralittoral to bathyal depths:
+We focus on the Gulf of Lion in the northwestern Mediterranean. This region offers good coverage across most data sources involved, with diverse substrate types (sand, mud, coarse sediments, seagrass meadows) and spatial sampling across 165 unique locations. The Gulf of Lion also spans multiple biozones from infralittoral to bathyal depths:
 
 ```{r}
 #| label: define-study-area-bbox
 # Study area: Gulf of Lion for habitats and environmental data
-study_bbox <- c(xmin = 3, ymin = 41, xmax = 7, ymax = 44)
+study_bbox <- c(xmin = 3, ymin = 42.5, xmax = 7, ymax = 44)
 
-# Create bbox polygon for visualisation
+# Create bbox polygon for visualisation (WGS 84) and spatial operations (EPSG:3035)
 bbox_polygon <- sf::st_as_sfc(sf::st_bbox(study_bbox, crs = 4326))
+bbox_polygon_3035 <- sf::st_transform(bbox_polygon, 3035)
 ```
 
 ```{r}
 #| label: fig-study-area
-#| echo: false
+#| code-fold: true
 #| fig-cap: "Study area: Gulf of Lion in the northwestern Mediterranean"
 
 # Get Mediterranean coastlines
@@ -162,19 +150,272 @@ med_countries <- rnaturalearth::ne_countries(
   sf::st_crop(c(xmin = -2, ymin = 38, xmax = 12, ymax = 46))
 
 ggplot() +
-  geom_sf(data = med_countries, fill = "gray90", color = "gray60", linewidth = 0.3) +
-  geom_sf(data = bbox_polygon, fill = NA, color = "#0077BE", linewidth = 1.5) +
+  geom_sf(
+    data = med_countries,
+    fill = "gray90",
+    color = "gray60",
+    linewidth = 0.3
+  ) +
+  geom_sf(data = bbox_polygon, fill = NA, color = "#004494", linewidth = 1.5) +
   coord_sf(xlim = c(-2, 12), ylim = c(38, 46)) +
   labs(x = NULL, y = NULL) +
   theme_minimal() +
   theme(panel.grid = element_line(color = "gray85", linewidth = 0.2))
 ```
 
+## Retrieving Seabed Habitat Data
+
+Our first data source is seabed habitat polygons from EMODnet Seabed Habitats. These polygons define the spatial framework for our biozone characterisation, providing EUNIS habitat codes, substrate types, and biozone classifications across the study area.
+
+### Connecting to EMODnet Seabed Habitats WFS
+
+For an introduction to working with WFS services and the `emodnet.wfs` package, see [Tutorial 1](tutorial-01.qmd). Here we apply the same workflow to the Seabed Habitats service.
+
+```{r}
+#| label: init-habitats-wfs
+habitat_wfs <- emodnet_init_wfs_client(
+  service = "seabed_habitats_general_datasets_and_products"
+)
+```
+
+### Exploring Habitat Layers
+
+We need habitat polygons from the [EUSeaMap](https://emodnet.ec.europa.eu/en/euseamap), the broad-scale predictive habitat map for European seas. The service contains many layers, so we filter by title to find the EUSeaMap products:
+
+```{r}
+#| label: explore-habitat-layers
+#| cache: true
+habitat_layers <- emodnet_get_wfs_info(habitat_wfs)
+
+# Search for EUSeaMap layers by title
+habitat_layers |>
+  filter(grepl("EUSeaMap", title)) |>
+  select(layer_name, title)
+```
+
+The results show separate layers for energy, substrate, biozone, and two habitat classification systems (EUNIS 2007 and EUNIS 2019). We choose `eusm2025_eunis2019_full` because EUNIS 2019 is the current classification standard and this layer includes both the habitat code and the substrate and biozone attributes we need.
+
+### Understanding Habitat Classifications
+
+Let's examine the attribute structure of the habitat layer:
+
+```{r}
+#| label: inspect-habitat-attributes
+#| cache: true
+habitat_attrs <- layer_attribute_descriptions(
+  wfs = habitat_wfs,
+  layer = "eusm2025_eunis2019_full"
+)
+
+habitat_attrs
+```
+
+Key attributes include:
+
+-   **`eunis2019c`**: EUNIS 2019 habitat classification (level 3)
+-   **`eunis2019d`**: Human-readable EUNIS 2019 habitat description
+-   **`substrate`**: Seabed substrate type
+-   **`biozone`**: Biological zone
+
+Let's check what habitat values are present across the full layer (not just our study area) using `layer_attribute_inspect()`:
+
+```{r}
+#| label: explore-habitat-types
+#| cache: true
+eunis_values <- layer_attribute_inspect(
+  wfs = habitat_wfs,
+  layer = "eusm2025_eunis2019_full",
+  attribute = "eunis2019c"
+)
+
+eunis_values
+```
+
+Scrolling through the values, you will notice that not all entries are clean EUNIS codes. Some contain `"Na"` (polygons with no habitat classification) and others contain `"or"` (e.g. `"MB551 or MB552"`), representing polygons where the classification is ambiguous between two habitat types. Let's quantify how many polygons across the entire layer are affected:
+
+```{r}
+#| label: count-invalid-habitat-values
+eunis_values |>
+  filter(.data[["."]] == "Na" | grepl("or", .data[["."]]))
+```
+
+These are data gaps in the EUSeaMap product itself, not specific to our study area. Since these values are not valid EUNIS codes, they would cause problems in downstream joins. We filter them out server-side using CQL to avoid downloading polygons we cannot use.
+
+### Building an Attribute CQL Filter
+
+We start by extracting the geometry column name for the BBOX filter:
+
+```{r}
+#| label: habitat-geom-col
+habitat_geom_col <- habitat_attrs$name[habitat_attrs$geometry]
+```
+
+We also want to combine the spatial BBOX filter with **attribute filters** to exclude the problematic `eunis2019c` values we identified above. CQL supports combining conditions with `AND`: we use `<>` to exclude exact matches and `NOT LIKE` with `%` wildcards for pattern matching. For more on attribute filtering syntax, see the [emodnet.wfs ECQL filtering vignette](https://emodnet.github.io/emodnet.wfs/articles/ecql_filtering.html#filtering-by-attributes).
+
+```{r}
+#| label: habitat-cql-filter
+habitat_cql_filter <- sprintf(
+  "BBOX(%s, %s, %s, %s, %s, 'EPSG:4326') AND eunis2019c <> 'Na' AND eunis2019c NOT LIKE '%%or%%'",
+  habitat_geom_col,
+  study_bbox["xmin"],
+  study_bbox["ymin"],
+  study_bbox["xmax"],
+  study_bbox["ymax"]
+)
+
+habitat_cql_filter
+```
+
+The `<>` operator excludes polygons where `eunis2019c` is exactly `"Na"`, and `NOT LIKE '%or%'` excludes any value containing the substring `"or"` (the `%` characters are CQL wildcards matching any sequence of characters). Note the `%%` in the `sprintf()` call: this is R's escape sequence to produce a literal `%` in the output string.
+
+### Downloading Habitat Polygons
+
+Now we download with the combined spatial and attribute filter. The habitat layer's native CRS is Web Mercator (EPSG:3857), but we request **EPSG:3035** (ETRS89-extended / LAEA Europe) via `crs = 3035`. This is an [equal-area projection](../concepts.qmd#why-this-matters-for-marine-spatial-analysis) well suited to European marine data: every cell and polygon covers the same ground area regardless of latitude, which matters for zonal statistics and spatial joins later in the tutorial:
+
+```{r}
+#| label: download-habitat-polygons
+#| cache: true
+seabed_habitats <- emodnet_get_layers(
+  wfs = habitat_wfs,
+  layers = "eusm2025_eunis2019_full",
+  cql_filter = habitat_cql_filter,
+  outputFormat = "application/json",
+  simplify = TRUE,
+  crs = 3035
+)
+
+nrow(seabed_habitats)
+```
+
+### Cropping Polygons to the Study Area
+
+The WFS server returns any polygon that overlaps our bounding box, but it returns each polygon in its entirety. Some polygons, particularly large deep-sea habitat types like the abyssal plain, may extend far beyond our study area. We can see this by checking the bounding box of the downloaded data:
+
+```{r}
+#| label: check-habitat-bbox
+st_bbox(seabed_habitats)
+```
+
+The extent is much larger than our study area (`r study_bbox["xmin"]`--`r study_bbox["xmax"]`°E, `r study_bbox["ymin"]`--`r study_bbox["ymax"]`°N). Leaving these oversized polygons in place causes two problems: it can skew analyses by including data outside the area of interest, and later, when we extract zonal statistics from rasters constrained to our bounding box, the overhanging parts of polygons produce `NaN` values (the raster has no cells to average over those areas).
+
+We fix this with `sf::st_crop()`, which clips all geometries to a target rectangle. We use `bbox_polygon_3035`, the EPSG:3035 version of our study area polygon created at the start of the tutorial:
+
+```{r}
+#| label: crop-habitat-polygons
+seabed_habitats <- seabed_habitats |>
+  st_crop(bbox_polygon_3035)
+
+st_bbox(seabed_habitats)
+```
+
+The bounding box now matches our study area.
+
+### Inspecting Downloaded Data
+
+Let's preview the key columns. Each row is a polygon with a EUNIS habitat code, a human-readable description, substrate type, and biozone:
+
+```{r}
+#| label: preview-habitat-polygons
+seabed_habitats |>
+  select(eunis2019c, eunis2019d, substrate, biozone) |>
+  head(10)
+```
+
+::: {.callout-note}
+The WFS layer may use a different name for its geometry column (e.g. `the_geom`, `msGeometry`), but after download the `sf` package standardises the column name to `geometry`. This is normal and applies to all WFS downloads throughout this tutorial.
+:::
+
+The geometry column contains `sf MULTIPOLYGON` features. Each habitat feature is a polygon (or collection of polygons) delineating an area of seabed with a particular classification. The columns show:
+
+- **`eunis2019c`**: the EUNIS 2019 level 3 code (e.g. `MB552`)
+- **`eunis2019d`**: the human-readable habitat description
+- **`substrate`**: the physical substrate (e.g. Sand, Mud, Coarse substrate)
+- **`biozone`**: the depth zone (e.g. Infralittoral, Deep circalittoral)
+
+The `biozone` variable represents depth zones from shallow (Infralittoral) to deep (Abyssal). We convert it to an ordered factor for meaningful analysis along depth gradients, and standardise `substrate` casing (the source data mixes "SAND" and "Sand"):
+
+```{r}
+#| label: order-biozone
+biozone_levels <- c(
+  "Infralittoral",
+  "Shallow circalittoral",
+  "Deep circalittoral",
+  "Upper bathyal",
+  "Lower bathyal",
+  "Abyssal"
+)
+
+seabed_habitats <- seabed_habitats |>
+  mutate(
+    biozone = factor(biozone, levels = biozone_levels, ordered = TRUE),
+    substrate = str_to_sentence(substrate)
+  )
+```
+
+We can confirm the CQL filter worked by checking the unique `eunis2019c` values in the downloaded data:
+
+```{r}
+#| label: verify-clean-eunis
+sort(unique(seabed_habitats$eunis2019c))
+```
+
+All clean EUNIS codes, with no `"Na"` or `"or"` values. Let's see which habitat types are most common in our study area:
+
+```{r}
+#| label: habitat-type-summary
+# Summarise habitat types present
+seabed_habitats |>
+  st_drop_geometry() |>
+  count(eunis2019c, sort = TRUE) |>
+  head(10)
+```
+
+### Visualising Seabed Habitats
+
+```{r}
+#| label: fig-seabed-habitats
+#| code-fold: true
+#| fig-cap: "Seabed habitat classification in the Gulf of Lion (EUNIS 2019)"
+#| fig-height: 10
+#| fig-width: 8
+
+ggplot() +
+  geom_sf(data = med_countries, fill = "gray90", colour = "gray70") +
+  geom_sf(
+    data = seabed_habitats,
+    aes(fill = str_wrap(eunis2019d, width = 50)),
+    colour = NA,
+    alpha = 0.8
+  ) +
+  coord_sf(
+    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
+    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
+  ) +
+  scale_fill_viridis_d(option = "turbo", name = NULL) +
+  labs(title = "Seabed Habitats (EUNIS 2019)") +
+  theme_minimal() +
+  theme(
+    legend.position = "bottom",
+    legend.text = element_text(size = 9),
+    legend.key.size = unit(0.4, "cm"),
+    plot.margin = margin(2, 2, 2, 2)
+  ) +
+  guides(fill = guide_legend(ncol = 2, override.aes = list(alpha = 1)))
+```
+
 ## Retrieving Species Occurrence Data
 
-Our first data source is benthic species occurrence records from EMODnet Biology. The Gulf of Lion has excellent coverage with over 16,000 records from 165 sampling locations, providing a rich species pool for trait analysis. These records have been matched to the World Register of Marine Species (WoRMS), ensuring taxonomic consistency.
+Next, we retrieve benthic species occurrence records from EMODnet Biology. These records have been matched to the World Register of Marine Species (WoRMS), ensuring taxonomic consistency, and each record is pre-matched to a EUNIS habitat code via the EUSeaMap grid, allowing us to link occurrences to the habitat polygons we just downloaded.
+
+::: {.callout-tip collapse="true"}
+## Taxonomic matching with the worrms package
+
+The data we use here are already matched to WoRMS, but if you need to match your own species lists to the WoRMS taxonomic backbone, the [`worrms`](https://cran.r-project.org/package=worrms) R package provides a programmatic interface to WoRMS. It supports fuzzy name matching, retrieval of accepted names and synonyms, and lookup of taxonomic hierarchies, useful for standardising species names across datasets.
+:::
 
 ### Connecting to EMODnet Biology WFS
+
+We follow the same discovery workflow as for the habitat service above.
 
 ```{r}
 #| label: init-biology-wfs
@@ -193,14 +434,17 @@ bio_layers <- emodnet_get_wfs_info(bio_wfs)
 # Filter for benthos-related layers
 bio_layers |>
   filter(grepl("benthos", layer_name, ignore.case = TRUE)) |>
-  select(layer_name, title)
+  select(layer_name, title, abstract) |>
+  # Keep first paragraph of abstract for display
+  mutate(abstract = str_extract(abstract, "^[^\n]+")) |>
+  knitr::kable()
 ```
 
-The `eb185_benthos_full_matched` layer contains benthic occurrence records that have been matched to WoRMS, providing standardised species identifications with AphiaIDs (unique WoRMS identifiers).
+We choose `eb185_benthos_full_matched` because it contains individual occurrence records with coordinates, each matched to WoRMS (providing AphiaIDs we can use to link to trait data) and pre-matched to EUNIS habitat codes via the EUSeaMap grid. The `benthos_europe` layer, by contrast, provides gridded presence/absence summaries rather than individual occurrence records, so it is less suited to point-level analysis.
 
 ### Understanding Layer Structure
 
-Before downloading, let's examine what attributes are available:
+Before downloading, let's examine what attributes are available (see [Tutorial 1](tutorial-01.qmd#understanding-layer-structure) for more on inspecting WFS layer metadata):
 
 ```{r}
 #| label: inspect-benthos-attributes
@@ -215,14 +459,17 @@ benthos_attrs
 
 Key attributes for our analysis include:
 
-- **`aphiaid`**: WoRMS identifier for linking to trait databases
-- **`scientificname`**: Species name for display
-- **`lon`**, **`lat`**: Coordinates
-- **`year`**: Sampling year
+-   **`st_point`**: Geometry column. We need to know this column name to construct spatial CQL filters (e.g. bounding box queries), so we extract it programmatically below
+-   **`aphiaid`**: WoRMS identifier for linking to trait databases
+-   **`scientificname`**: Species name for display
+-   **`lon`**, **`lat`**: Coordinates
+-   **`year`**: Sampling year
+-   **`eusm_polygon_id`**: Link to the EUSeaMap grid polygon
+-   **`EUNIS2019C`**, **`EUNIS2019D`**: EUNIS 2019 habitat classification (level 3 and 4), already matched via the EUSeaMap grid
 
 ### Downloading Occurrence Data
 
-We use a CQL filter to request records from the Gulf of Lion study area:
+We use a [CQL BBOX filter](tutorial-01.qmd#filtering-by-location-pre-download) to request only records within our study area:
 
 ```{r}
 #| label: define-benthos-bbox-filter
@@ -240,6 +487,15 @@ benthos_bbox_filter <- sprintf(
 )
 ```
 
+The resulting CQL filter combines the geometry column name with the `study_bbox` coordinates into a string that the WFS server interprets as a spatial constraint:
+
+```{r}
+#| label: print-benthos-bbox-filter
+benthos_bbox_filter
+```
+
+Now we download the data with `emodnet_get_layers()`, passing our CQL filter to restrict the query to the study area. As with the habitat data, we request EPSG:3035 so both vector datasets share the same equal-area CRS. We use [GeoJSON format](tutorial-01.qmd#why-use-geojson-format) (`outputFormat = "application/json"`) for faster downloads and simpler geometry types, and set `simplify = TRUE` to return a single `sf` data frame rather than a list of layers:
+
 ```{r}
 #| label: download-benthos-occurrences
 #| cache: true
@@ -248,21 +504,31 @@ benthos_occurrences <- emodnet_get_layers(
   layers = "eb185_benthos_full_matched",
   cql_filter = benthos_bbox_filter,
   outputFormat = "application/json",
-  simplify = TRUE
+  simplify = TRUE,
+  crs = 3035
 )
 
 # Check the result
 nrow(benthos_occurrences)
 ```
 
+### Inspecting Downloaded Data
+
+A quick preview of the data. Note the `sf POINT` geometry type in the geometry column: each occurrence is a single coordinate, in contrast to the habitat **polygons** we retrieved earlier:
+
 ```{r}
 #| label: preview-benthos
 benthos_occurrences |>
-  select(aphiaid, scientificname, lon, lat, year) |>
+  select(aphiaid, scientificname, lon, lat, year, EUNIS2019C) |>
   head(10)
 ```
 
-### Data Quality Check
+Each occurrence has been pre-matched to a EUNIS 2019 habitat code. Let's see which habitat types are represented and confirm the codes are clean:
+
+```{r}
+#| label: preview-benthos-eunis
+sort(unique(benthos_occurrences$EUNIS2019C))
+```
 
 Let's examine the taxonomic diversity and data completeness:
 
@@ -287,6 +553,7 @@ cat(sprintf(
 
 ```{r}
 #| label: fig-benthos-occurrences
+#| code-fold: true
 #| fig-cap: "Benthic species occurrence records in the Gulf of Lion"
 
 ggplot() +
@@ -303,154 +570,17 @@ ggplot() +
   ) +
   labs(
     title = "Benthic Species Occurrences",
-    subtitle = sprintf("%d records in the Gulf of Lion", nrow(benthos_occurrences))
+    subtitle = sprintf(
+      "%d records in the Gulf of Lion",
+      nrow(benthos_occurrences)
+    )
   ) +
   theme_minimal()
 ```
 
-## Retrieving Seabed Habitat Data
-
-Next, we retrieve seabed habitat polygons to classify our occurrence records by habitat type.
-
-### Connecting to EMODnet Seabed Habitats WFS
-
-```{r}
-#| label: init-habitats-wfs
-hab_wfs <- emodnet_init_wfs_client(service = "seabed_habitats_general_datasets_and_products")
-```
-
-### Exploring Habitat Layers
-
-```{r}
-#| label: explore-habitat-layers
-#| cache: true
-hab_layers <- emodnet_get_wfs_info(hab_wfs)
-
-# Search for EU seabed habitat layers
-hab_layers |>
-  filter(grepl("eu.*seabed|seabed.*habitat", layer_name, ignore.case = TRUE)) |>
-  select(layer_name, title)
-```
-
-### Understanding Habitat Classifications
-
-Let's examine the attribute structure of the habitat layer:
-
-```{r}
-#| label: inspect-habitat-attributes
-#| cache: true
-habitat_attrs <- layer_attribute_descriptions(
-  wfs = hab_wfs,
-  layer = "eusm_2023_eunis2019_full"
-)
-
-habitat_attrs
-```
-
-Key attributes include:
-
-- **`eunis2019c`**: EUNIS 2019 habitat classification (level 3)
-- **`eunis2019d`**: EUNIS 2019 habitat classification (level 4, more detailed)
-- **`substrate`**: Seabed substrate type
-- **`biozone`**: Biological zone
-
-Let's check what habitat values are present:
-
-```{r}
-#| label: explore-habitat-types
-#| cache: true
-layer_attribute_inspect(
-  wfs = hab_wfs,
-  layer = "eusm_2023_eunis2019_full",
-  attribute = "eunis2019c"
-)
-```
-
-### Downloading Habitat Polygons
-
-```{r}
-#| label: download-habitat-polygons
-#| cache: true
-# Get geometry column name
-habitat_geom_col <- habitat_attrs$name[habitat_attrs$geometry]
-
-# Create BBOX filter
-habitat_bbox_filter <- sprintf(
-  "BBOX(%s, %s, %s, %s, %s, 'EPSG:4326')",
-  habitat_geom_col,
-  study_bbox["xmin"],
-  study_bbox["ymin"],
-  study_bbox["xmax"],
-  study_bbox["ymax"]
-)
-
-seabed_habitats <- emodnet_get_layers(
-  wfs = hab_wfs,
-  layers = "eusm_2023_eunis2019_full",
-  cql_filter = habitat_bbox_filter,
-  outputFormat = "application/json",
-  simplify = TRUE
-)
-
-# Convert biozone to ordered factor (shallow to deep)
-biozone_levels <- c(
- "Infralittoral",
- "Shallow circalittoral",
-  "Deep circalittoral",
-  "Upper bathyal",
-  "Lower bathyal",
-  "Abyssal"
-)
-
-seabed_habitats <- seabed_habitats |>
-  mutate(biozone = factor(biozone, levels = biozone_levels, ordered = TRUE))
-
-nrow(seabed_habitats)
-```
-
-The `biozone` variable represents depth zones from shallow (Infralittoral) to deep (Abyssal), which we convert to an ordered factor for meaningful analysis along depth gradients.
-
-```{r}
-#| label: habitat-type-summary
-# Summarise habitat types present
-seabed_habitats |>
-  st_drop_geometry() |>
-  count(eunis2019c, sort = TRUE) |>
-  head(10)
-```
-
-### Visualising Seabed Habitats
-
-```{r}
-#| label: fig-seabed-habitats
-#| fig-cap: "Seabed habitat classification in the Gulf of Lion (EUNIS 2019). Colours represent different EUNIS habitat codes."
-#| fig-height: 6
-#| fig-width: 8
-
-ggplot() +
-  geom_sf(data = med_countries, fill = "gray90", colour = "gray70") +
-
-  geom_sf(
-    data = seabed_habitats,
-    aes(fill = eunis2019c),
-    colour = NA,
-    alpha = 0.8
-  ) +
-  coord_sf(
-    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
-    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
-  ) +
-  scale_fill_viridis_d(option = "turbo") +
-  labs(title = "Seabed Habitats (EUNIS 2019)") +
-  theme_minimal() +
-  theme(legend.position = "none")
-```
-
-The map shows the spatial distribution of EUNIS 2019 habitat types across the Gulf of Lion. The diversity of colours reflects the variety of seabed habitats present, from shallow coastal sediments to deeper muddy substrates. Rather than listing all `r n_distinct(seabed_habitats$eunis2019c)` habitat codes in a legend, we summarise the main habitat categories below:
-
 ## Retrieving Bathymetry Data
 
-Bathymetry (water depth) provides essential environmental context. We retrieve this from EMODnet Bathymetry using WCS.
+Bathymetry (water depth) provides essential environmental context for our habitat characterisation. We retrieve this from EMODnet Bathymetry using [WCS](../concepts.qmd#wcs-web-coverage-service) (see [Tutorial 2](tutorial-02.qmd) for an introduction to working with the `emodnet.wcs` package).
 
 ### Connecting to EMODnet Bathymetry WCS
 
@@ -461,70 +591,59 @@ bathy_wcs <- emdn_init_wcs_client(service = "bathymetry")
 
 ### Exploring Available Coverages
 
+`emdn_get_coverage_ids()` lists all available coverage layers from the service:
+
 ```{r}
 #| label: list-bathymetry-coverages
 bathy_coverage_ids <- emdn_get_coverage_ids(bathy_wcs)
 bathy_coverage_ids
 ```
 
-We'll use the mean depth product:
+The coverage IDs encode the product type and reference year. The `mean` coverages provide the gridded mean depth, with year suffixes indicating different releases of the bathymetric compilation. We use the most recent release (`emodnet__mean_2022`). `emdn_get_coverage_info()` provides metadata including the spatial resolution, extent, and coordinate reference system:
 
 ```{r}
 #| label: get-bathymetry-info
 bathy_info <- emdn_get_coverage_info(
   wcs = bathy_wcs,
-  coverage_ids = "emodnet__mean_2020"
+  coverage_ids = "emodnet__mean_2022"
 )
 
 bathy_info |>
   knitr::kable()
 ```
 
+The resolution is approximately 1/960 of a degree (~115 m at this latitude), which is much finer than our bottom temperature raster (~4.2 km). This difference in resolution is one reason we extract zonal statistics from each raster separately later on.
+
 ### Downloading Bathymetry
 
-The full-resolution bathymetry data can be quite large, so we download it in tiles and mosaic them together:
+We download the bathymetry raster for our study area using `emdn_get_coverage()`, which returns a `SpatRaster`. We set `nil_values_as_na = TRUE` so that any nil values declared in the coverage metadata (e.g. `-9999` for "no data") are converted to R's `NA`:
 
 ```{r}
 #| label: download-bathymetry
-# Split the bbox into smaller tiles to avoid download limits
-# Create a 2x2 grid of tiles
-lon_breaks <- seq(study_bbox["xmin"], study_bbox["xmax"], length.out = 3)
-lat_breaks <- seq(study_bbox["ymin"], study_bbox["ymax"], length.out = 3)
+bathymetry <- emdn_get_coverage(
+  wcs = bathy_wcs,
+  coverage_id = "emodnet__mean_2022",
+  bbox = study_bbox,
+  nil_values_as_na = TRUE
+)
 
-# Download each tile
-tiles <- list()
-tile_idx <- 1
-for (i in 1:2) {
-  for (j in 1:2) {
-    tile_bbox <- c(
-      xmin = lon_breaks[i],
-      ymin = lat_breaks[j],
-      xmax = lon_breaks[i + 1],
-      ymax = lat_breaks[j + 1]
-    )
-    tiles[[tile_idx]] <- emdn_get_coverage(
-      wcs = bathy_wcs,
-      coverage_id = "emodnet__mean_2020",
-      bbox = tile_bbox
-    )
-    tile_idx <- tile_idx + 1
-  }
-}
-
-# Combine tiles into a SpatRasterCollection and merge
-tiles_collection <- terra::sprc(tiles)
-bathymetry <- terra::merge(tiles_collection)
 bathymetry
 ```
 
-Note that EMODnet bathymetry values are typically **negative** (depth below sea level). Let's verify and convert to positive depth values for easier interpretation:
+### Inspecting Downloaded Data
+
+EMODnet bathymetry uses the convention of **negative values for depth below sea level** and positive values for elevation above it. Since our bounding box overlaps the coastline, the raster includes both marine cells (negative) and land cells (positive). We can check the value range with `terra::global()`, which computes a summary statistic across all cells of a `SpatRaster`:
+
+```{r}
+#| label: check-bathymetry-range
+terra::global(bathymetry, range, na.rm = TRUE)
+```
+
+The negative minimum confirms deep marine areas. The positive maximum (~1,900 m) may seem surprising for a marine study area, but our bounding box extends to 44°N, which reaches well inland over southern France into the foothills of the Pyrenees and Massif Central. EMODnet bathymetry is a digital terrain model that covers both sea and land, so these terrestrial elevations are included in the download. We set land cells (positive values) to `NA`, then negate the remaining values so that depth is expressed as a positive number (deeper = larger):
 
 ```{r}
 #| label: process-bathymetry
-# Check value range
-global(bathymetry, range, na.rm = TRUE)
-
-# Convert to positive depth values
+bathymetry[bathymetry > 0] <- NA
 depth <- -1 * bathymetry
 names(depth) <- "depth_m"
 ```
@@ -533,6 +652,7 @@ names(depth) <- "depth_m"
 
 ```{r}
 #| label: fig-bathymetry
+#| code-fold: true
 #| fig-cap: "Bathymetry of the Gulf of Lion (depth in metres)"
 
 ggplot() +
@@ -542,7 +662,16 @@ ggplot() +
     name = "Depth (m)",
     na.value = "white",
     option = "mako",
-    direction = -1
+    direction = -1,
+    breaks = c(0, 200, 500, 1000, 2000, 2500),
+    # Allocate more of the colour gradient to shallow depths so that
+    # shelf features and canyon heads are visible despite the large
+    # overall depth range (~0–2700 m)
+    values = scales::rescale(
+      c(0, 50, 200, 500, 1000, 2000, 2500),
+      to = c(0, 1),
+      from = c(0, 2500)
+    )
   ) +
   coord_sf(
     xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
@@ -550,76 +679,238 @@ ggplot() +
   ) +
   labs(title = "Gulf of Lion Bathymetry") +
   theme_minimal() +
-  theme(legend.position = "bottom")
+  theme(legend.position = "bottom") +
+  guides(
+    fill = guide_colorbar(
+      barwidth = 15,
+      barheight = 0.5,
+      title.position = "top"
+    )
+  )
 ```
 
 ## Retrieving Bottom Temperature
 
-Bottom temperature provides insight into thermal niches and may influence body size distributions. We access this from the [Copernicus Marine Service](https://marine.copernicus.eu/) using the [`CopernicusMarine`](https://pepijn-devries.github.io/CopernicusMarine/) R package.
+Bottom temperature provides insight into thermal niches and is a key variable for characterising environmental conditions across biozones. We access this from the [Copernicus Marine Service](https://marine.copernicus.eu/) (CMEMS), the marine component of the EU's [Copernicus](https://www.copernicus.eu/) Earth observation programme. Copernicus is the Earth observation component of the EU's Space programme, drawing on satellite and in-situ observations to monitor the planet. All Copernicus data and products are provided on a free, full and open basis under EU regulation. CMEMS provides ocean analysis, forecast and reanalysis products covering the global ocean and European regional seas. We interact with it in R using the [`CopernicusMarine`](https://pepijn-devries.github.io/CopernicusMarine/) package.
 
-### Understanding the Data Product
+### How Copernicus Marine Service data is organised
 
-We use the GLOBAL_MULTIYEAR_PHY_001_030 product, which provides ocean reanalysis data including bottom temperature. Let's explore what's available:
+The EMODnet services we used above follow [OGC standards](../concepts.qmd#ogc-standards-and-spatial-data-types): WFS serves vector features and WCS serves raster coverages, each accessed through a service client. Copernicus Marine Service organises its data differently. Data is stored in both NetCDF and [zarr](../concepts.qmd#zarr-.zarr) (a cloud-native array format) and discovered through a [STAC](https://stacspec.org/) (SpatioTemporal Asset Catalog) catalogue. The `CopernicusMarine` package handles this transparently (using the zarr stores for efficient spatial subsetting), but the terminology differs from the OGC services:
+
+| EMODnet | Copernicus Marine | Copernicus Example |
+|---------|-------------------|--------------------|
+| Service (e.g., `"biology"`) | **Product** (a dataset with a unique ID) | `MEDSEA_MULTIYEAR_PHY_006_004` |
+| Layer (e.g., `"eb185_benthos_full_matched"`) | **Layer** (a specific temporal resolution or subset) | `cmems_mod_med_phy-temp_my_4.2km_P1M-m` |
+| Attributes (WFS) or Bands (WCS) | **Variables** (physical quantities stored in the array) | `bottomT`, `thetao` |
+| 2D features or grids | **Multi-dimensional arrays** with longitude, latitude, depth, and time | 4D datacube |
+
+Because the data is multi-dimensional, `cms_download_subset()` returns a [`stars`](../concepts.qmd#stars---spatiotemporal-arrays) object rather than the `sf` or `terra` objects returned by EMODnet services. For more background, see the [stars](../concepts.qmd#stars---spatiotemporal-arrays) and [zarr](../concepts.qmd#zarr-.zarr) sections in the Geospatial Concepts page.
+
+The metadata returned by `CopernicusMarine` functions follows the STAC specification. For a general introduction to what STAC is and how catalogues, collections, and items relate, see the [STAC intro tutorial](https://stacspec.org/en/tutorials/intro-to-stac/). In practice, the deeply nested metadata structures can be challenging to navigate, but contain rich information about layers, variables, dimensions, and time ranges, as we explore below.
+
+The discovery workflow follows a similar pattern to EMODnet: list what is available, inspect metadata, then download a subset.
+
+### Choosing a Data Product
+
+Bottom temperature is typically available in physical reanalysis products, identified by `MULTIYEAR_PHY` in their product IDs. `cms_products_list()` lists all available products; we filter to physical reanalysis:
 
 ```{r}
 #| label: explore-copernicus-products
 #| cache: true
-# List available products
+# List physical reanalysis products
 cms_products_list() |>
-  filter(grepl("GLOBAL_MULTIYEAR_PHY", product_id)) |>
-  select(product_id, title)
+  filter(grepl("MULTIYEAR_PHY", product_id)) |>
+  select(product_id, title) |>
+  knitr::kable()
 ```
+
+A Copernicus **product** plays the same role as an EMODnet **service** (like `"biology"` or `"bathymetry"`): it is a thematic collection that groups related layers together. For small study areas, regional products typically offer higher resolution and are specifically validated for that region. For our Gulf of Lion study, the Mediterranean product ([MEDSEA_MULTIYEAR_PHY_006_004](https://data.marine.copernicus.eu/product/MEDSEA_MULTIYEAR_PHY_006_004/description)) provides \~4.2 km resolution compared to \~8 km for the global product.
+
+### Browsing Available Variables
+
+Unlike OGC services where each layer contains a single dataset, Copernicus products are built on a datacube architecture. A single product can bundle multiple physical variables (temperature, salinity, currents) across multiple layers. We can get a high-level overview of all variables available across the entire product using `cms_product_details()`:
+
+```{r}
+#| label: explore-med-product-details
+#| cache: true
+med_product <- cms_product_details("MEDSEA_MULTIYEAR_PHY_006_004")
+
+# allVariables aggregates human-readable variable names across ALL layers
+med_product$properties$allVariables |> unlist()
+```
+
+This confirms the product includes "Sea water potential temperature at sea floor", which is what we need. However, this is a product-wide summary: it aggregates variable names across all layers, so not every variable listed here is necessarily available in every layer. To find out exactly which variables are available in which layers, and to get the variable `id`s needed for downloading, we need to drill into the layer-level metadata.
+
+### Discovering Layers and Their Variables
+
+A product contains multiple **layers**, each offering a different temporal resolution of the same underlying data (e.g. daily vs monthly means). `cms_product_services()` lists them:
+
+```{r}
+#| label: explore-med-services
+#| cache: true
+med_services <- cms_product_services("MEDSEA_MULTIYEAR_PHY_006_004")
+
+# Each row is a layer
+med_services$id
+```
+
+The layer `id`s encode the variable group and temporal resolution (e.g., `temp` for temperature, `P1M-m` for monthly means, `P1D-m` for daily). Version suffixes (e.g., `_202511`) can be omitted when downloading.
+
+Each layer carries rich variable metadata in its `cube:variables` property. The [STAC datacube extension](https://github.com/stac-extensions/datacube) defines a base set of fields (`dimensions`, `type`, `unit`, `description`), and Copernicus Marine adds its own fields on top. Let's examine the structure by drilling into the first variable of the first layer. `med_services` is a data frame with list-columns, where each row is a layer. `properties[[1]]` accesses the STAC metadata for the first layer, `cube:variables` is a named list of that layer's variables, and `[[1]]` selects the first variable entry:
+
+```{r}
+#| label: inspect-cube-variables
+# Examine the metadata structure of the first variable in the first layer
+str(med_services$properties[[1]]$`cube:variables`[[1]], max.level = 2)
+```
+
+The standard STAC datacube fields include `dimensions` (which axes the variable spans), `type` (`"data"` for measured values), and `unit`. In standard STAC, each variable is identified by its key name in the `cube:variables` map. Copernicus Marine also stores this as an explicit `id` field inside each variable object, along with other Copernicus-specific additions: `name$en` (a human-readable description), `standardName` (the [CF convention](https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html) name), and visualisation hints like `colormapId` and value ranges.
+
+We can use these fields to build a clear mapping of layers to their variables. Since we need bottom temperature, we filter to the temperature layers:
+
+```{r}
+#| label: check-temp-layer-variables
+# Extract variable details from each temperature layer
+med_services |>
+  filter(grepl("tem", id, ignore.case = TRUE)) |>
+  rowwise() |>
+  reframe(
+    layer = id,
+    variable = purrr::map_chr(properties$`cube:variables`, "id"),
+    description = purrr::map_chr(properties$`cube:variables`, \(x) x$name$en),
+    unit = purrr::map_chr(properties$`cube:variables`, "unit")
+  ) |>
+  knitr::kable()
+```
+
+All temperature layers contain `bottomT` (sea floor potential temperature) and `thetao` (potential temperature through the water column). For comprehensive documentation of all variable names, layer naming conventions, and production methodology, see the [Product User Manual (PUM)](https://documentation.marine.copernicus.eu/PUM/CMEMS-MED-PUM-006-004.pdf).
+
+We choose the monthly means layer (`P1M-m`) rather than daily (`P1D-m`) or climatology. Monthly data provides enough temporal resolution to compute a meaningful multi-year average while keeping the download size manageable. The climatology layer would seem ideal (it provides pre-computed long-term averages), but it has additional dimensions that the `CopernicusMarine` package cannot currently handle. Computing our own average from monthly data gives us full control over the time period.
+
+```{r}
+#| label: select-temp-layer
+# Select the monthly temperature layer
+temp_monthly <- med_services |>
+  filter(id == "cmems_mod_med_phy-temp_my_4.2km_P1M-m_202511")
+```
+
+The `cube:dimensions` property tells us the available **temporal extent** and **time steps** for our chosen layer, which is essential for knowing what date range we can request:
+
+```{r}
+#| label: check-temp-layer-time
+time_dim <- temp_monthly$properties[[1]]$`cube:dimensions`$time
+
+# Temporal extent (start and end dates)
+cat("Temporal extent:", time_dim$extent[[1]], "to", time_dim$extent[[2]])
+cat("Total time steps:", length(time_dim$values))
+```
+
+The layer spans from 1987 to the present with monthly time steps. We now have all four pieces of information needed to download: the **product** ID, the **layer** ID (we choose monthly means, `P1M-m`), the **variable** ID (`bottomT`), and the available **time range**.
+
+### Choosing a Time Period
+
+To choose a meaningful time range for the temperature data, we should match it to when our benthos occurrences were actually sampled:
+
+```{r}
+#| label: fig-occurrence-year-distribution
+#| code-fold: true
+#| fig-cap: "Number of benthic occurrence records per sampling year"
+#| fig-height: 3.5
+ggplot(benthos_occurrences, aes(x = year)) +
+  geom_bar(aes(fill = after_stat(count)), width = 0.8) +
+  scale_fill_continuous(guide = "none", trans = "reverse") +
+  scale_x_continuous(breaks = sort(unique(benthos_occurrences$year))) +
+  labs(x = "Year", y = "Number of records") +
+  theme_minimal() +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1))
+```
+
+Sampling is concentrated in two periods: a large 1998 campaign and a main cluster from 2004 to 2018 with internal gaps. We download monthly temperature spanning 1998 to 2015, covering both periods while keeping the download small (~6 MB).
 
 ### Downloading Bottom Temperature
 
-We download bottom temperature for our study area. The `cms_download_subset()` function returns a `stars` object that we can convert to a `terra` raster:
+`cms_download_subset()` returns a [`stars`](../concepts.qmd#stars---spatiotemporal-arrays) object (a multi-dimensional array):
 
 ```{r}
 #| label: download-bottom-temperature
-# Download bottom temperature subset
-# This returns a stars object directly into memory
 bottom_temp_stars <- cms_download_subset(
-  product = "GLOBAL_MULTIYEAR_PHY_001_030",
-  layer = "cmems_mod_glo_phy_my_0.083deg_P1M-m",
+  product = "MEDSEA_MULTIYEAR_PHY_006_004",
+  layer = "cmems_mod_med_phy-temp_my_4.2km_P1M-m",
   variable = "bottomT",
   region = study_bbox,
-  timerange = c("2020-01-01", "2020-12-31")
+  timerange = c("1998-01-01", "2015-12-31")
 )
+```
 
-# The stars object may have multiple time slices - aggregate to mean
-# Use stars functions to handle the aggregation properly
-if ("time" %in% names(stars::st_dimensions(bottom_temp_stars))) {
-  bottom_temp_mean_stars <- stars::st_apply(
-    bottom_temp_stars,
-    c("longitude", "latitude"),
-    mean,
-    na.rm = TRUE
-  )
-} else {
-  bottom_temp_mean_stars <- bottom_temp_stars
-}
+### Inspecting the Stars Object
 
-# Convert to terra raster using sf as intermediate
-# First drop units if present
-bottom_temp_mean_stars[[1]] <- as.numeric(bottom_temp_mean_stars[[1]])
+Let's examine the structure. Printing a `stars` object shows its attribute (the variable, with summary statistics) and its dimensions:
 
-# Convert via sf
-bottom_temp_sf <- sf::st_as_sf(bottom_temp_mean_stars, as_points = TRUE)
-bottom_temp_mean <- terra::rasterize(
-  terra::vect(bottom_temp_sf),
-  terra::rast(
-    extent = terra::ext(
-      study_bbox["xmin"], study_bbox["xmax"],
-      study_bbox["ymin"], study_bbox["ymax"]
-    ),
-    resolution = 0.083,  # ~8km resolution matching the data
-    crs = "EPSG:4326"
-  ),
-  field = names(bottom_temp_sf)[1]
-)
+```{r}
+#| label: inspect-stars-object
+bottom_temp_stars
+```
+
+`st_dimensions()` shows the three dimensions of the object:
+
+```{r}
+#| label: inspect-stars-dims
+stars::st_dimensions(bottom_temp_stars)
+```
+
+Each monthly time step is a 2D spatial grid (longitude × latitude), and the full object stacks these along the time dimension. We can inspect the time values directly:
+
+```{r}
+#| label: inspect-stars-time
+time_vals <- stars::st_get_dimension_values(bottom_temp_stars, "time")
+cat("Time steps:", length(time_vals))
+cat("First:", format(time_vals[1]))
+cat("Last:", format(time_vals[length(time_vals)]))
+```
+
+### Filtering to Sampled Years
+
+Since our download spans 1998-2015 but not all years have occurrence data, we filter the time dimension to keep only months from years when sampling actually occurred. This gives a temperature mean that reflects the conditions organisms were experiencing.
+
+```{r}
+#| label: filter-stars-sampled-years
+sampled_years <- unique(benthos_occurrences$year)
+keep <- as.integer(format(time_vals, "%Y")) %in% sampled_years
+bottom_temp_sampled <- bottom_temp_stars[,,, keep]
+
+cat("Retained", sum(keep), "of", length(keep), "monthly time steps")
+cat("Years kept:", sort(unique(as.integer(format(time_vals[keep], "%Y")))))
+```
+
+`stars` objects are indexed as `[attribute, dim1, dim2, dim3]`, where the first position selects attributes (variables like `bottomT`) and the rest select along the spatial and temporal dimensions. Leaving a position empty keeps all values along that axis. So `[,,,keep]` means: all attributes, all longitudes, all latitudes, filter time.
+
+### Computing the Mean Temperature
+
+`st_apply()` works like R's `apply()`: the first argument names the dimensions to **keep**, and the function is applied over all remaining dimensions. Here, `c("longitude", "latitude")` keeps the spatial dimensions and applies `mean` across time, collapsing all retained monthly time steps into a single 2D layer:
+
+```{r}
+#| label: compute-mean-temperature
+bottom_temp_mean <- bottom_temp_sampled |>
+  stars::st_apply(c("longitude", "latitude"), mean, na.rm = TRUE)
+```
+
+### Converting Stars to Terra Raster
+
+The rest of our analysis uses `terra` for raster operations (zonal statistics, extraction). To convert from `stars` to a `terra` `SpatRaster`, we need to address a grid compatibility issue: the Copernicus Marine grid is **rectilinear** (cell spacing along longitude and latitude is not perfectly uniform), but `terra::rast()` requires a **regular** grid with uniform cell sizes.
+
+`st_warp()` resamples a `stars` object onto a target grid. We build that target with `st_as_stars()`, passing `st_bbox(bottom_temp_mean)` to preserve the original spatial extent and setting `dx` and `dy` to 1/24° to match the native Copernicus Marine resolution (~4.2 km at this latitude):
+
+```{r}
+#| label: convert-to-terra
+bottom_temp_mean <- bottom_temp_mean |>
+  stars::st_warp(stars::st_as_stars(
+    sf::st_bbox(bottom_temp_mean),
+    dx = 1 / 24,
+    dy = 1 / 24
+  )) |>
+  terra::rast()
 names(bottom_temp_mean) <- "bottom_temp_C"
 
-# Quick check
 bottom_temp_mean
 ```
 
@@ -627,7 +918,8 @@ bottom_temp_mean
 
 ```{r}
 #| label: fig-bottom-temperature
-#| fig-cap: "Mean annual bottom temperature in the Gulf of Lion (2020)"
+#| code-fold: true
+#| fig-cap: "Mean bottom temperature in the Gulf of Lion (sampled years, 1998-2015)"
 
 ggplot() +
   geom_spatraster(data = bottom_temp_mean) +
@@ -635,46 +927,28 @@ ggplot() +
   scale_fill_viridis_c(
     name = "Temperature (°C)",
     na.value = "white",
-    option = "inferno"
+    option = "turbo"
   ) +
   coord_sf(
     xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
     ylim = c(study_bbox["ymin"], study_bbox["ymax"])
   ) +
-  labs(title = "Bottom Temperature (2020 mean)") +
+  labs(title = "Mean Bottom Temperature (sampled years)") +
   theme_minimal() +
   theme(legend.position = "bottom")
 ```
 
-::: {.callout-tip collapse="true"}
-## Finding available products and layers
-
-Use `cms_products_list()` to browse available products and `cms_product_details()` to explore layers within a product:
-```r
-# List all products
-products <- cms_products_list()
-
-# Get details for a specific product
-cms_product_details("GLOBAL_MULTIYEAR_PHY_001_030")
-```
-:::
-
 ::: {.callout-note collapse="true"}
-## Working with Copernicus Marine Data
+## What else is available from Copernicus Marine?
 
-The CopernicusMarine package provides access to a wealth of oceanographic data:
+In this tutorial we retrieved bottom temperature from a physical reanalysis product. The Copernicus Marine Service also provides:
 
-- **Physical reanalysis**: Temperature, salinity, currents
-- **Biogeochemical**: Nutrients, chlorophyll, oxygen
-- **Multiple depths**: Surface to bottom
+-   **Other physical variables**: Salinity, currents, sea level, mixed layer depth
+-   **Biogeochemical products**: Nutrients, chlorophyll, dissolved oxygen, pH
+-   **Multiple temporal resolutions**: Daily, monthly, and climatological means
+-   **Multiple depths**: Surface to bottom, including full 3D fields
 
-Key functions:
-
-- `cms_products_list()`: Browse available products
-- `cms_product_details()`: Get metadata for a specific product
-- `cms_download_subset()`: Download data for a region and time period
-
-See the [package documentation](https://pepijn-devries.github.io/CopernicusMarine/) for complete usage examples.
+Browse available products with `cms_products_list()` and follow the same discovery workflow shown above. See the [CopernicusMarine package documentation](https://pepijn-devries.github.io/CopernicusMarine/) for further examples.
 :::
 
 ## Linking Trait Data from MOBS
@@ -683,57 +957,60 @@ The Marine Organism Body Size (MOBS) database provides body size measurements fo
 
 ### About MOBS
 
-The MOBS database [@mccallum2025] compiles body size data from literature sources, standardised to maximum body length where possible. This makes it ideal for linking to occurrence data that includes WoRMS identifiers.
+The MOBS database [@mccallum2025] compiles body size data from literature sources, standardised to maximum body length where possible. This makes it ideal for linking to occurrence data that includes WoRMS identifiers (AphiaIDs).
 
 ### Loading MOBS Data
 
-The MOBS database is available from GitHub. We download and filter to species present in our Gulf of Lion occurrence data:
+The MOBS database is available as a CSV file on GitHub, which we can download directly with `readr::read_csv()`. The database uses WoRMS AphiaIDs as its species identifier (allowing us to join to our occurrence data) and stores body size measurements (length, diameter/width, height) in centimetres. We pipe the result through `janitor::clean_names()` to convert the mixed-case column names (e.g. `valid_aphiaID`, `scientificName`) to consistent snake_case.
 
 ```{r}
 #| label: download-mobs
 #| cache: true
-# Download MOBS database from GitHub
-# The database uses valid_AphiaID and size measurements in cm
 mobs_url <- "https://raw.githubusercontent.com/crmcclain/MOBS_OPEN/main/data_all_112224.csv"
-mobs_raw <- read.csv(mobs_url)
+mobs_raw <- readr::read_csv(mobs_url, show_col_types = FALSE) |>
+  janitor::clean_names()
 
-# Preview structure
-names(mobs_raw)
+head(mobs_raw, 10)
 ```
 
-The MOBS database includes body size measurements (length, diameter/width, height) in centimetres. We'll use the length measurement and convert to millimetres for consistency.
+We'll use the length measurement and convert from centimetres to millimetres. First, we filter MOBS to species present in our occurrence data, keeping only rows that have a length measurement (not all records do), convert units and select the columns we need:
 
 ```{r}
 #| label: filter-mobs-to-occurrences
-# Get unique AphiaIDs from Gulf of Lion occurrences
 occurrence_aphiaids <- unique(benthos_occurrences$aphiaid)
 
-# Filter MOBS to matching species and select relevant columns
-# Convert length from cm to mm
-mobs_matched <- mobs_raw |>
-  filter(valid_aphiaID %in% occurrence_aphiaids) |>
-  mutate(MaxLength_mm = length_cm * 10) |>  # Convert cm to mm
-  select(valid_aphiaID, scientificName, MaxLength_mm, phylum, class) |>
-  # Take max length per species if multiple records
-  group_by(valid_aphiaID, scientificName, phylum, class) |>
-  summarise(MaxLength_mm = max(MaxLength_mm, na.rm = TRUE), .groups = "drop") |>
-  filter(!is.na(MaxLength_mm), is.finite(MaxLength_mm))
+mobs_filtered <- mobs_raw |>
+  filter(valid_aphia_id %in% occurrence_aphiaids, !is.na(length_cm)) |>
+  mutate(length_mm = length_cm * 10) |>
+  select(aphiaid = valid_aphia_id, scientific_name, length_mm, phylum, class)
 
-# How many species matched?
+cat("Rows matched:", nrow(mobs_filtered))
+cat("Unique species:", n_distinct(mobs_filtered$aphiaid))
+cat("Duplicated AphiaIDs:", sum(duplicated(mobs_filtered$aphiaid)))
+```
+
+Some species have multiple measurements from different literature sources. For our analysis we need a single value per species, so we take the maximum body length:
+
+```{r}
+#| label: summarise-mobs-per-species
+mobs_matched <- mobs_filtered |>
+  group_by(aphiaid, scientific_name, phylum, class) |>
+  summarise(max_length_mm = max(length_mm), .groups = "drop")
+
 n_matched <- nrow(mobs_matched)
 n_total <- length(occurrence_aphiaids)
 
 cat(sprintf(
-  "Matched %d of %d species (%.1f%%) to MOBS body size data\n",
-  n_matched, n_total, 100 * n_matched / n_total
+  "Matched %d of %d species (%.1f%%) to MOBS body size data",
+  n_matched,
+  n_total,
+  100 * n_matched / n_total
 ))
 ```
 
 ```{r}
 #| label: preview-mobs-matched
-mobs_matched |>
-  arrange(desc(MaxLength_mm)) |>
-  head(15)
+head(mobs_matched, 10)
 ```
 
 ### Body Size Distribution
@@ -742,550 +1019,354 @@ Let's examine the distribution of body sizes among our matched species:
 
 ```{r}
 #| label: fig-body-size-distribution
+#| code-fold: true
 #| fig-cap: "Distribution of maximum body length for Gulf of Lion benthic species with MOBS data (log scale)"
 
-ggplot(mobs_matched, aes(x = MaxLength_mm)) +
-  geom_histogram(bins = 30, fill = "#0077BE", colour = "white", alpha = 0.7) +
+n_bins <- 30
+log_range <- diff(range(log10(mobs_matched$max_length_mm)))
+binwidth <- log_range / n_bins
+
+ggplot(mobs_matched, aes(x = max_length_mm)) +
+  geom_histogram(
+    bins = n_bins,
+    fill = "#0077BE",
+    colour = "white",
+    alpha = 0.7
+  ) +
+  geom_density(
+    aes(
+      y = after_stat(density) * nrow(mobs_matched) * binwidth,
+      colour = "Kernel density estimate"
+    ),
+    linewidth = 0.8,
+    key_glyph = "path"
+  ) +
+  scale_colour_manual(values = "black", name = NULL) +
   scale_x_log10() +
   labs(
     title = "Body Size Distribution",
-    subtitle = sprintf("n = %d Gulf of Lion species with MOBS data", nrow(mobs_matched)),
+    subtitle = sprintf(
+      "n = %d Gulf of Lion species with MOBS data",
+      nrow(mobs_matched)
+    ),
     x = "Maximum body length (mm, log scale)",
     y = "Number of species"
   ) +
+  theme_minimal() +
+  theme(legend.position = "top")
+```
+
+The distribution is roughly log-normal with a median around 30 mm, but the density curve reveals clear bimodality with peaks near 10 mm and 50 mm. Breaking this down by taxonomic class (@fig-bodysize-by-class) helps explain the pattern.
+
+```{r}
+#| label: fig-bodysize-by-class
+#| code-fold: true
+#| fig-cap: "Body size distributions by taxonomic class for Gulf of Lion benthic species with MOBS length data (classes with fewer than 5 species excluded)"
+#| fig-height: 4
+
+class_counts <- mobs_matched |>
+  filter(!is.na(class)) |>
+  count(class) |>
+  filter(n >= 5) |>
+  mutate(label = sprintf("%s (n = %d)", class, n))
+
+plot_data <- mobs_matched |>
+  inner_join(class_counts, by = "class") |>
+  mutate(label = reorder(label, max_length_mm, FUN = median))
+
+ggplot(plot_data, aes(x = label, y = max_length_mm)) +
+  geom_violin(fill = "#0077BE", alpha = 0.5, colour = "white") +
+  geom_boxplot(width = 0.15, outlier.size = 0.8) +
+  scale_y_log10() +
+  coord_flip() +
+  labs(
+    x = NULL,
+    y = "Maximum body length (mm, log scale)"
+  ) +
   theme_minimal()
 ```
+
+The first peak in the histogram is driven by malacostracan crustaceans (190 species, median ~10 mm), while the second reflects the larger polychaetes (231 species) and bivalves (132 species). Together these three classes make up over 90% of the matched species.
 
 ## Spatial Data Integration
 
-Now we integrate all our data sources through spatial operations:
+Now we bring our data sources together. The integration produces two datasets, each serving a different role in the biozone characterisation:
 
-1. **Characterise habitats environmentally**: Extract mean depth and temperature per habitat type
-2. **Join occurrences to habitats**: Assign each species occurrence to a seabed habitat
-3. **Link trait data**: Match species to body size from MOBS
+-   **Polygon level** (`habitat_env`): We compute environmental summaries (mean depth and temperature) for each habitat polygon, using the full set of polygons in the study area. This dataset characterises the biozones themselves: their habitat composition, substrate makeup, and environmental conditions.
+-   **Occurrence level** (`occurrences_in_habitat`): We use `sf::st_join()` to spatially assign each species record to the habitat polygon it falls within, giving it that polygon's substrate and biozone. We also join body size data from MOBS via AphiaID. This dataset drives the body size analysis.
 
-This approach characterises habitats by their environmental conditions rather than extracting values at individual occurrence points, which is more robust given the patchy distribution of occurrence records.
+### Checking CRS Alignment
 
-### Ensuring CRS Alignment
-
-First, let's ensure all spatial data use the same coordinate reference system:
+Before combining spatial datasets, we verify their [coordinate reference systems](../concepts.qmd#coordinate-reference-systems-crs). Both vector datasets were downloaded in EPSG:3035, while the rasters are in WGS 84 (EPSG:4326):
 
 ```{r}
 #| label: check-crs-alignment
-# Check CRS of each dataset
-st_crs(benthos_occurrences)$input
+# Vector datasets (EPSG:3035)
 st_crs(seabed_habitats)$input
+st_crs(benthos_occurrences)$input
+
+# Raster datasets (WGS 84)
 crs(depth, describe = TRUE)$name
+crs(bottom_temp_mean, describe = TRUE)$name
 ```
 
-```{r}
-#| label: align-crs
-# Transform all to WGS84 if needed
-if (st_crs(benthos_occurrences) != st_crs(4326)) {
-  benthos_occurrences <- st_transform(benthos_occurrences, 4326)
-}
+The vector datasets share EPSG:3035, so spatial joins will work directly. For the raster extractions below, we reproject the rasters to match the polygons.
 
-if (st_crs(seabed_habitats) != st_crs(4326)) {
-  seabed_habitats <- st_transform(seabed_habitats, 4326)
-}
-```
+### Extracting Environmental Conditions
 
-### Characterising Habitats by Environmental Conditions
+Rather than sampling a single centroid point per polygon, we compute **zonal statistics**, summarising all raster cells that fall within each habitat polygon. `terra::extract()` takes a raster and a set of polygons, identifies which raster cells fall within each polygon, and applies a summary function (here `mean`) across them. This captures the spatial extent of each habitat and produces more robust environmental characterisations, especially for large or irregularly shaped polygons. Depth and temperature have different native resolutions, so we extract each separately to avoid resampling.
 
-We extract mean depth and temperature for each habitat type by aggregating raster values across habitat polygons. This gives us a robust environmental characterisation of each habitat class:
+Because our habitat polygons are in EPSG:3035 (an [equal-area projection](../concepts.qmd#why-this-matters-for-marine-spatial-analysis)), we reproject the rasters to match before extraction. In an equal-area projection every raster cell covers the same ground area regardless of latitude, so each cell contributes equally to the mean:
 
 ```{r}
 #| label: extract-habitat-environment
-# Extract mean depth per habitat type
-# First aggregate habitat polygons by type, then extract
-habitat_types <- seabed_habitats |>
+habitat_env <- seabed_habitats |>
   st_drop_geometry() |>
-  distinct(eunis2019c, substrate, biozone)
-
-# For efficiency, sample centroids of habitat polygons
-# and extract environmental values
-habitat_centroids <- seabed_habitats |>
-  st_centroid() |>
-  suppressWarnings()
-
-# Extract depth and temperature at centroids
-centroid_coords <- habitat_centroids |>
-  st_coordinates() |>
-  as.data.frame()
-
-habitat_centroids$depth_m <- terra::extract(depth, centroid_coords)$depth_m
-habitat_centroids$bottom_temp_C <- terra::extract(bottom_temp_mean, centroid_coords)$bottom_temp_C
-
-# Summarise environmental conditions by habitat type
-habitat_env_summary <- habitat_centroids |>
-  st_drop_geometry() |>
-  group_by(eunis2019c, substrate, biozone) |>
-  summarise(
-    n_polygons = n(),
-    mean_depth_m = mean(depth_m, na.rm = TRUE),
-    sd_depth_m = sd(depth_m, na.rm = TRUE),
-    mean_temp_C = mean(bottom_temp_C, na.rm = TRUE),
-    sd_temp_C = sd(bottom_temp_C, na.rm = TRUE),
-    .groups = "drop"
-  ) |>
-  filter(!is.na(mean_depth_m))
-
-habitat_env_summary |>
-  mutate(across(where(is.numeric), ~ round(.x, 1))) |>
-  head(15) |>
-  knitr::kable()
-```
-
-### Spatial Join: Occurrences to Habitats
-
-We use `st_join()` to link species occurrences to habitat polygons. Only points that fall within a mapped habitat polygon receive a habitat classification:
-
-```{r}
-#| label: spatial-join-habitats
-# Join occurrences to habitat polygons
-# Points outside habitat polygons get NA for habitat columns
-occurrences_with_habitat <- benthos_occurrences |>
-  st_join(seabed_habitats, join = st_within)
-
-# Check how many got habitat assignments
-n_with_habitat <- sum(!is.na(occurrences_with_habitat$eunis2019c))
-cat(sprintf(
-  "%d of %d occurrences (%.1f%%) fall within mapped habitat polygons\n",
-  n_with_habitat, nrow(occurrences_with_habitat),
-  100 * n_with_habitat / nrow(occurrences_with_habitat)
-))
-
-# Filter to occurrences with habitat data
-occurrences_in_habitat <- occurrences_with_habitat |>
-  filter(!is.na(eunis2019c))
-
-cat(sprintf(
-  "Retained %d occurrences with habitat assignments for analysis\n",
-  nrow(occurrences_in_habitat)
-))
-```
-
-### Joining Trait Data
-
-We link species to their body size data via AphiaID, and add habitat-level environmental data:
-
-```{r}
-#| label: join-trait-data
-# Join MOBS data to occurrences
-occurrences_complete <- occurrences_in_habitat |>
-  left_join(
-    mobs_matched,
-    by = c("aphiaid" = "valid_aphiaID")
-  ) |>
-  # Add habitat-level environmental data
-  # Join by all grouping columns to avoid duplicates
-  left_join(
-    habitat_env_summary |> select(eunis2019c, substrate, biozone, mean_depth_m, mean_temp_C),
-    by = c("eunis2019c", "substrate", "biozone")
+  mutate(
+    mean_depth_m = terra::extract(
+      terra::project(depth, "EPSG:3035"),
+      seabed_habitats,
+      fun = mean,
+      na.rm = TRUE
+    )$depth_m,
+    mean_temp_C = terra::extract(
+      terra::project(bottom_temp_mean, "EPSG:3035"),
+      seabed_habitats,
+      fun = mean,
+      na.rm = TRUE
+    )$bottom_temp_C
   )
-
-# Summary of complete records
-occurrences_complete |>
-  st_drop_geometry() |>
-  summarise(
-    total_records = n(),
-    with_habitat = sum(!is.na(eunis2019c)),
-    with_substrate = sum(!is.na(substrate)),
-    with_biozone = sum(!is.na(biozone)),
-    with_body_size = sum(!is.na(MaxLength_mm)),
-    with_env_data = sum(!is.na(mean_depth_m))
-  ) |>
-  knitr::kable()
 ```
 
-## Analysing Trait-Environment Relationships
+### Joining Occurrences to Habitats and Traits
 
-With our integrated dataset, we can explore how body size varies across habitats and environmental gradients.
-
-### Body Size by Habitat Type
+We combine the body size join (by AphiaID) and the spatial habitat join (by location) in a single pipeline. `inner_join()` retains only species with MOBS body size data, and `st_join()` assigns each occurrence to the habitat polygon it falls within, adding that polygon's `substrate` and `biozone`. Because both datasets are in EPSG:3035, the spatial join uses planar geometry directly:
 
 ```{r}
-#| label: tbl-bodysize-by-habitat
-#| tbl-cap: "Mean body size by seabed habitat type"
+#| label: join-occurrences-habitats-traits
+occurrences_in_habitat <- benthos_occurrences |>
+  inner_join(mobs_matched, by = "aphiaid") |>
+  st_join(select(seabed_habitats, substrate, biozone)) |>
+  filter(!is.na(biozone))
 
-habitat_summary <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(eunis2019c), !is.na(MaxLength_mm)) |>
-  group_by(eunis2019c) |>
-  summarise(
-    n_records = n(),
-    n_species = n_distinct(aphiaid),
-    mean_length_mm = mean(MaxLength_mm, na.rm = TRUE),
-    sd_length_mm = sd(MaxLength_mm, na.rm = TRUE),
-    median_length_mm = median(MaxLength_mm, na.rm = TRUE),
-    .groups = "drop"
-  ) |>
-  filter(n_records >= 10) |>
-  arrange(desc(mean_length_mm))
-
-habitat_summary |>
-  mutate(across(where(is.numeric), ~ round(.x, 1))) |>
-  knitr::kable()
+cat(sprintf(
+  "Retained %d of %d occurrences (%.1f%%) with body size and habitat data",
+  nrow(occurrences_in_habitat),
+  nrow(benthos_occurrences),
+  100 * nrow(occurrences_in_habitat) / nrow(benthos_occurrences)
+))
 ```
 
+A preview of the joined dataset, showing each occurrence with its species name, body size, habitat code, substrate, and biozone:
+
 ```{r}
-#| label: fig-bodysize-by-habitat
-#| fig-cap: "Body size distribution by seabed habitat type"
+#| label: preview-joined-occurrences
+occurrences_in_habitat |>
+  st_drop_geometry() |>
+  select(scientificname, max_length_mm, EUNIS2019C, substrate, biozone) |>
+  head(10)
+```
+
+## Characterising Biozones
+
+Biozones represent the vertical zonation of the seabed, from the sunlit infralittoral through the circalittoral to the deep bathyal and abyssal zones. This depth gradient is the primary ecological axis structuring benthic communities, influencing light availability, temperature, pressure, and food supply. The EUSeaMap habitat layer encodes biozone alongside habitat type and substrate for each polygon, giving us a natural framework to bring together all our data sources.
+
+### Habitat Composition by Biozone
+
+Different EUNIS habitat types are distributed across biozones. Using the full set of habitat polygons in the study area, this stacked bar chart shows which habitat types occur in each zone:
+
+```{r}
+#| label: fig-habitat-by-biozone
+#| code-fold: true
+#| fig-cap: "Proportional EUNIS habitat type composition within each biozone"
 #| fig-height: 7
 
-plot_data <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(eunis2019c), !is.na(MaxLength_mm)) |>
-  group_by(eunis2019c) |>
-  filter(n() >= 10) |>
-  ungroup()
+habitat_biozone_data <- habitat_env |>
+  filter(!is.na(biozone), !is.na(eunis2019d)) |>
+  count(biozone, eunis2019d)
 
-ggplot(plot_data, aes(x = reorder(eunis2019c, MaxLength_mm, FUN = median), y = MaxLength_mm)) +
-  geom_boxplot(fill = "#0077BE", alpha = 0.5, outlier.size = 0.5) +
-  scale_y_log10() +
-  coord_flip() +
-  labs(
-    title = "Body Size by Habitat Type",
-    x = "Seabed habitat",
-    y = "Maximum body length (mm, log scale)"
+ggplot(
+  habitat_biozone_data,
+  aes(x = biozone, y = n, fill = str_wrap(eunis2019d, width = 50))
+) +
+  geom_bar(stat = "identity", position = "fill") +
+  scale_fill_viridis_d(option = "turbo", name = NULL) +
+  scale_y_continuous(labels = scales::percent) +
+  labs(x = "Biozone", y = "Proportion of polygons") +
+  theme_minimal() +
+  theme(
+    axis.text.x = element_text(angle = 30, hjust = 1),
+    legend.position = "bottom",
+    legend.text = element_text(size = 9),
+    legend.key.size = unit(0.4, "cm")
   ) +
-  theme_minimal()
+  guides(fill = guide_legend(ncol = 2, override.aes = list(alpha = 1)))
 ```
 
-### Body Size by Substrate Type
+Habitat diversity decreases sharply with depth. The infralittoral supports the greatest variety of EUNIS habitat types (including Posidonia beds, rock, sand, and coarse sediment), and the shallow circalittoral retains several types (coralligène, coarse and mixed sediments, muddy detritic bottoms). From the deep circalittoral downwards, each biozone maps onto a single habitat type in our matched data, all mud-dominated.
 
-The spatial join with habitat polygons allows us to examine how body size varies by substrate type - something the embedded EUNIS codes alone cannot reveal.
+### Substrate Composition by Biozone
 
-```{r}
-#| label: tbl-bodysize-by-substrate
-#| tbl-cap: "Mean body size by substrate type"
-
-substrate_summary <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(substrate), !is.na(MaxLength_mm)) |>
-  group_by(substrate) |>
-  summarise(
-    n_records = n(),
-    n_species = n_distinct(aphiaid),
-    mean_length_mm = mean(MaxLength_mm, na.rm = TRUE),
-    sd_length_mm = sd(MaxLength_mm, na.rm = TRUE),
-    median_length_mm = median(MaxLength_mm, na.rm = TRUE),
-    .groups = "drop"
-  ) |>
-  filter(n_records >= 10) |>
-  arrange(desc(mean_length_mm))
-
-substrate_summary |>
-  mutate(across(where(is.numeric), ~ round(.x, 1))) |>
-  knitr::kable()
-```
+Substrate type (the physical material of the seabed) also varies with depth:
 
 ```{r}
-#| label: fig-bodysize-by-substrate
-#| fig-cap: "Body size distribution by seabed substrate type"
+#| label: fig-substrate-by-biozone
+#| code-fold: true
+#| fig-cap: "Proportional substrate composition within each biozone"
 #| fig-height: 5
 
-substrate_plot_data <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(substrate), !is.na(MaxLength_mm)) |>
-  group_by(substrate) |>
-  filter(n() >= 10) |>
-  ungroup()
+substrate_biozone_data <- habitat_env |>
+  filter(!is.na(biozone), !is.na(substrate)) |>
+  count(biozone, substrate)
 
-if (nrow(substrate_plot_data) > 0) {
-  ggplot(substrate_plot_data, aes(x = reorder(substrate, MaxLength_mm, FUN = median), y = MaxLength_mm)) +
-    geom_boxplot(fill = "#8B4513", alpha = 0.6, outlier.size = 0.5) +
-    scale_y_log10() +
-    coord_flip() +
-    labs(
-      title = "Body Size by Substrate Type",
-      x = "Substrate",
-      y = "Maximum body length (mm, log scale)"
-    ) +
-    theme_minimal()
-} else {
-  message("No substrate data available for plotting")
-}
+ggplot(substrate_biozone_data, aes(x = biozone, y = n, fill = substrate)) +
+  geom_bar(stat = "identity", position = "fill") +
+  scale_fill_brewer(palette = "Set3", name = "Substrate") +
+  scale_y_continuous(labels = scales::percent) +
+  labs(x = "Biozone", y = "Proportion of polygons") +
+  theme_minimal() +
+  theme(axis.text.x = element_text(angle = 30, hjust = 1))
 ```
 
-### Body Size by Biozone
+Substrate composition also shows a clear transition with depth. The infralittoral is again the most diverse, featuring Posidonia meadows, coarse and mixed sediment, rock, and sand. The shallow and deep circalittoral retain a mix of substrates (sand, muddy sand, coarse sediment, fine mud), but fine mud becomes increasingly dominant. From the upper bathyal downwards, fine mud dominates all biozones, reaching 100% in the abyssal zone.
 
-Biozones represent the vertical zonation of the seabed (e.g., infralittoral, circalittoral, bathyal), which correlates with light availability, temperature, and pressure.
+### Environmental Conditions by Biozone
+
+Using the depth (EMODnet WCS) and bottom temperature (Copernicus Marine) data we extracted earlier, we can characterise the environmental conditions within each biozone. Each point represents one habitat polygon:
 
 ```{r}
-#| label: tbl-bodysize-by-biozone
-#| tbl-cap: "Mean body size by biozone"
+#| label: fig-env-by-biozone
+#| code-fold: true
+#| fig-cap: "Depth and bottom temperature distributions across biozones"
+#| fig-height: 4
+#| fig-width: 10
 
-biozone_summary <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(biozone), !is.na(MaxLength_mm)) |>
-  group_by(biozone) |>
-  summarise(
-    n_records = n(),
-    n_species = n_distinct(aphiaid),
-    mean_length_mm = mean(MaxLength_mm, na.rm = TRUE),
-    sd_length_mm = sd(MaxLength_mm, na.rm = TRUE),
-    median_length_mm = median(MaxLength_mm, na.rm = TRUE),
-    .groups = "drop"
-  ) |>
-  filter(n_records >= 10) |>
-  arrange(desc(mean_length_mm))
+env_data <- habitat_env |>
+  filter(!is.na(biozone), !is.na(mean_depth_m))
 
-biozone_summary |>
-  mutate(across(where(is.numeric), ~ round(.x, 1))) |>
-  knitr::kable()
+p_depth <- ggplot(env_data, aes(x = biozone, y = mean_depth_m)) +
+  geom_violin(fill = "#0077BE", alpha = 0.5, colour = "white") +
+  geom_boxplot(width = 0.15, outlier.size = 0.8) +
+  labs(x = NULL, y = "Mean depth (m)") +
+  theme_minimal() +
+  theme(axis.text.x = element_text(angle = 30, hjust = 1))
+
+p_temp <- ggplot(
+  env_data |> filter(!is.na(mean_temp_C)),
+  aes(x = biozone, y = mean_temp_C)
+) +
+  geom_violin(fill = "#E74C3C", alpha = 0.5, colour = "white") +
+  geom_boxplot(width = 0.15, outlier.size = 0.8) +
+  labs(x = NULL, y = "Mean bottom temperature (\u00b0C)") +
+  theme_minimal() +
+  theme(axis.text.x = element_text(angle = 30, hjust = 1))
+
+p_depth + p_temp
 ```
+
+Depth increases steadily across biozones as expected, from near-surface in the infralittoral to over 2,500 m in the abyssal. The upper and lower bathyal zones show the greatest variability in depth, spanning several hundred metres each. Bottom temperature shows a narrower overall range (~13 to 17 °C): the infralittoral and shallow circalittoral are warmer and more variable (reflecting seasonal and coastal influences), while the deeper biozones converge on a narrow band around 13 °C.
+
+### Body Size Distributions by Biozone
+
+Finally, we examine how body size varies across biozones. Ridge plots (from `ggridges`) show kernel density estimates stacked vertically, with fill colour mapped to body size. `scale` controls how much adjacent ridges overlap (0.9 keeps them mostly separate), and `rel_min_height` trims density tails below 1% of the peak to avoid long, thin artefacts:
 
 ```{r}
 #| label: fig-bodysize-by-biozone
+#| code-fold: true
 #| fig-cap: "Body size distribution by biozone"
 #| fig-height: 5
 
-biozone_plot_data <- occurrences_complete |>
+biozone_plot_data <- occurrences_in_habitat |>
   st_drop_geometry() |>
-  filter(!is.na(biozone), !is.na(MaxLength_mm)) |>
+  filter(!is.na(biozone), !is.na(max_length_mm)) |>
   group_by(biozone) |>
   filter(n() >= 10) |>
   ungroup()
 
-if (nrow(biozone_plot_data) > 0) {
-  ggplot(biozone_plot_data, aes(x = reorder(biozone, MaxLength_mm, FUN = median), y = MaxLength_mm)) +
-    geom_boxplot(fill = "#2E8B57", alpha = 0.6, outlier.size = 0.5) +
-    scale_y_log10() +
-    coord_flip() +
-    labs(
-      title = "Body Size by Biozone",
-      x = "Biozone",
-      y = "Maximum body length (mm, log scale)"
-    ) +
-    theme_minimal()
-} else {
-  message("No biozone data available for plotting")
-}
-```
-
-### Body Size Along Habitat Depth Gradient
-
-Using the mean depth of each habitat type, we can examine how body size varies along the depth gradient:
-
-```{r}
-#| label: fig-bodysize-depth
-#| fig-cap: "Relationship between body size and habitat mean depth"
-
-depth_plot_data <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(mean_depth_m), !is.na(MaxLength_mm), mean_depth_m > 0)
-
-ggplot(depth_plot_data, aes(x = mean_depth_m, y = MaxLength_mm)) +
-  geom_point(alpha = 0.2, size = 1, colour = "#0077BE") +
-  geom_smooth(method = "loess", colour = "darkred", fill = "pink", alpha = 0.3) +
-  scale_y_log10() +
+ggplot(
+  biozone_plot_data,
+  aes(x = max_length_mm, y = biozone)
+) +
+  geom_density_ridges_gradient(
+    aes(fill = after_stat(x)),
+    scale = 0.9,
+    rel_min_height = 0.01
+  ) +
+  scale_x_log10() +
+  scale_fill_viridis_c(
+    name = "Body size (mm)",
+    option = "plasma",
+    trans = "log10"
+  ) +
   labs(
-    title = "Body Size vs Habitat Depth",
-    x = "Mean habitat depth (m)",
-    y = "Maximum body length (mm, log scale)"
+    x = "Maximum body length (mm, log scale)",
+    y = "Biozone"
   ) +
   theme_minimal()
 ```
 
-### Habitat Depth Distribution
+The deeper biozones (lower bathyal, abyssal) are dominated by smaller-bodied species, while the shallower zones (infralittoral, circalittoral) show broader body size distributions extending to larger species. This pattern is consistent with the shift in taxonomic composition and environmental conditions across depth zones.
+
+We can break this down further by looking at taxonomic class within each biozone, using the same violin + boxplot approach as @fig-bodysize-by-class:
 
 ```{r}
-#| label: fig-depth-by-habitat
-#| fig-cap: "Mean depth of habitat types where species occur"
-#| fig-height: 6
-
-habitat_depth_data <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(eunis2019c), !is.na(mean_depth_m)) |>
-  group_by(eunis2019c) |>
-  filter(n() >= 10) |>
-  ungroup()
-
-ggplot(habitat_depth_data, aes(x = reorder(eunis2019c, mean_depth_m, FUN = median, na.rm = TRUE), y = mean_depth_m)) +
-  geom_boxplot(fill = "#228B22", alpha = 0.5) +
-  coord_flip() +
-  labs(
-    title = "Depth Distribution by Habitat Type",
-    x = "Seabed habitat",
-    y = "Mean habitat depth (m)"
-  ) +
-  theme_minimal()
-```
-
-### Body Size Along Habitat Temperature Gradient
-
-```{r}
-#| label: fig-bodysize-temperature
-#| fig-cap: "Relationship between body size and habitat mean bottom temperature"
-
-temp_plot_data <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(mean_temp_C), !is.na(MaxLength_mm))
-
-ggplot(temp_plot_data, aes(x = mean_temp_C, y = MaxLength_mm)) +
-  geom_point(alpha = 0.2, size = 1, colour = "#E74C3C") +
-  geom_smooth(method = "loess", colour = "darkblue", fill = "lightblue", alpha = 0.3) +
-  scale_y_log10() +
-  labs(
-    title = "Body Size vs Habitat Temperature",
-    x = "Mean habitat bottom temperature (°C)",
-    y = "Maximum body length (mm, log scale)"
-  ) +
-  theme_minimal()
-```
-
-### Body Size-Environment Interactions by Habitat Type
-
-To explore whether body size-environment relationships differ across habitat types, we create two-panel plots comparing the overall trend with habitat-specific patterns. We focus on habitats with sufficient data (at least 20 occurrences with body size data):
-
-```{r}
-#| label: fig-bodysize-depth-habitat
-#| fig-cap: "Body size vs depth: overall trend (left) compared with habitat-specific patterns (right)"
-#| fig-height: 5
-#| fig-width: 12
-
-# Filter to habitats with enough data for reliable trends
-depth_habitat_data <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(mean_depth_m), !is.na(MaxLength_mm), !is.na(eunis2019c), mean_depth_m > 0) |>
-  group_by(eunis2019c) |>
-  filter(n() >= 20) |>
-  ungroup()
-
-# Panel A: Overall trend
-p_depth_overall <- ggplot(depth_habitat_data, aes(x = mean_depth_m, y = MaxLength_mm)) +
-  geom_point(alpha = 0.3, size = 1, colour = "grey40") +
-  geom_smooth(method = "loess", colour = "black", fill = "grey70", linewidth = 1.5) +
-  scale_y_log10() +
-  labs(
-    title = "A) Overall trend",
-    x = "Mean habitat depth (m)",
-    y = "Maximum body length (mm)"
-  ) +
-  theme_minimal()
-
-# Panel B: By habitat type
-p_depth_habitat <- ggplot(depth_habitat_data, aes(x = mean_depth_m, y = MaxLength_mm, colour = eunis2019c)) +
-  geom_point(alpha = 0.4, size = 1.5) +
-  geom_smooth(method = "loess", se = FALSE, linewidth = 1.2) +
-  scale_y_log10() +
-  scale_colour_viridis_d(option = "turbo", name = "Habitat") +
-  labs(
-    title = "B) By habitat type",
-    x = "Mean habitat depth (m)",
-    y = NULL
-  ) +
-  theme_minimal() +
-  theme(legend.position = "bottom") +
-  guides(colour = guide_legend(nrow = 3, override.aes = list(size = 3)))
-
-p_depth_overall + p_depth_habitat
-```
-
-```{r}
-#| label: fig-bodysize-temp-habitat
-#| fig-cap: "Body size vs temperature: overall trend (left) compared with habitat-specific patterns (right)"
-#| fig-height: 5
-#| fig-width: 12
-
-# Filter to habitats with enough data
-temp_habitat_data <- occurrences_complete |>
-  st_drop_geometry() |>
-  filter(!is.na(mean_temp_C), !is.na(MaxLength_mm), !is.na(eunis2019c)) |>
-  group_by(eunis2019c) |>
-  filter(n() >= 20) |>
-
-  ungroup()
-
-# Panel A: Overall trend
-p_temp_overall <- ggplot(temp_habitat_data, aes(x = mean_temp_C, y = MaxLength_mm)) +
-  geom_point(alpha = 0.3, size = 1, colour = "grey40") +
-  geom_smooth(method = "loess", colour = "black", fill = "grey70", linewidth = 1.5) +
-  scale_y_log10() +
-  labs(
-    title = "A) Overall trend",
-    x = "Mean habitat temperature (°C)",
-    y = "Maximum body length (mm)"
-  ) +
-  theme_minimal()
-
-# Panel B: By habitat type
-p_temp_habitat <- ggplot(temp_habitat_data, aes(x = mean_temp_C, y = MaxLength_mm, colour = eunis2019c)) +
-  geom_point(alpha = 0.4, size = 1.5) +
-  geom_smooth(method = "loess", se = FALSE, linewidth = 1.2) +
-  scale_y_log10() +
-  scale_colour_viridis_d(option = "turbo", name = "Habitat") +
-  labs(
-    title = "B) By habitat type",
-    x = "Mean habitat temperature (°C)",
-    y = NULL
-  ) +
-  theme_minimal() +
-  theme(legend.position = "bottom") +
-  guides(colour = guide_legend(nrow = 3, override.aes = list(size = 3)))
-
-p_temp_overall + p_temp_habitat
-```
-
-```{r}
-#| label: fig-bodysize-habitat-facet
-#| fig-cap: "Body size distributions across habitat types, ordered by median body size"
+#| label: fig-bodysize-class-biozone
+#| code-fold: true
+#| fig-cap: "Body size distributions by taxonomic class within each biozone (classes with fewer than 5 species excluded)"
 #| fig-height: 8
 #| fig-width: 10
 
-facet_data <- occurrences_complete |>
+class_biozone_data <- occurrences_in_habitat |>
   st_drop_geometry() |>
-  filter(!is.na(MaxLength_mm), !is.na(eunis2019c)) |>
-  group_by(eunis2019c) |>
+  filter(!is.na(biozone), !is.na(max_length_mm), !is.na(class)) |>
+  group_by(biozone) |>
   filter(n() >= 10) |>
   ungroup()
 
-# Calculate median for ordering
-habitat_order <- facet_data |>
-  group_by(eunis2019c) |>
-  summarise(median_size = median(MaxLength_mm, na.rm = TRUE)) |>
-  arrange(median_size) |>
-  pull(eunis2019c)
+# Keep only classes with >= 5 species across all biozones
+class_keep <- class_biozone_data |>
+  distinct(aphiaid, class) |>
+  count(class) |>
+  filter(n >= 5)
 
-facet_data <- facet_data |>
-  mutate(eunis2019c = factor(eunis2019c, levels = habitat_order))
+class_biozone_data <- class_biozone_data |>
+  semi_join(class_keep, by = "class") |>
+  mutate(class = reorder(class, max_length_mm, FUN = median))
 
-ggplot(facet_data, aes(x = eunis2019c, y = MaxLength_mm, fill = eunis2019c)) +
-  geom_boxplot(alpha = 0.7, outlier.size = 0.5) +
+ggplot(class_biozone_data, aes(x = class, y = max_length_mm)) +
+  geom_violin(fill = "#0077BE", alpha = 0.5, colour = "white") +
+  geom_boxplot(width = 0.15, outlier.size = 0.5) +
   scale_y_log10() +
-  scale_fill_viridis_d(option = "turbo") +
+  coord_flip() +
+  facet_wrap(~biozone) +
   labs(
-    title = "Body Size Distribution by Habitat Type",
-    x = "EUNIS habitat type",
+    x = NULL,
     y = "Maximum body length (mm, log scale)"
   ) +
   theme_minimal() +
-  theme(
-    axis.text.x = element_text(angle = 45, hjust = 1),
-    legend.position = "none"
-  ) +
-  coord_flip()
+  theme(strip.text = element_text(face = "bold"))
 ```
 
 ## Interactive Map
 
-Let's create an interactive map showing species occurrences coloured by body size class, overlaid on seabed habitats:
+Let's create a map showing species occurrences coloured by body size class, overlaid on seabed habitats. We first bin continuous body lengths into discrete size classes using `cut()`:
 
 ```{r}
 #| label: create-bodysize-classes
 # Create body size classes for visualisation
-occurrences_for_map <- occurrences_complete |>
-  filter(!is.na(MaxLength_mm)) |>
+occurrences_for_map <- occurrences_in_habitat |>
+  filter(!is.na(max_length_mm)) |>
   mutate(
     size_class = cut(
-      MaxLength_mm,
+      max_length_mm,
       breaks = c(0, 10, 50, 200, 1000, Inf),
       labels = c("<10mm", "10-50mm", "50-200mm", "200-1000mm", ">1000mm"),
       right = FALSE
     )
   )
 ```
+
+The `tmap` package can produce interactive (Leaflet) maps with `tmap_mode("view")`. Here we layer habitat polygons under occurrence points, with pop-ups showing species name and traits:
 
 ```{r}
 #| label: fig-interactive-map
@@ -1310,9 +1391,8 @@ tm_shape(seabed_habitats) +
     fill_alpha = 0.7,
     popup.vars = c(
       "Species" = "scientificname",
-      "Body length (mm)" = "MaxLength_mm",
-      "Habitat" = "eunis2019c",
-      "Substrate" = "substrate",
+      "Body length (mm)" = "max_length_mm",
+      "Habitat" = "EUNIS2019C",
       "Biozone" = "biozone"
     )
   )
@@ -1321,89 +1401,98 @@ tm_shape(seabed_habitats) +
 ```{r}
 #| label: fig-interactive-map-render
 #| echo: false
-#| fig-cap: "Benthic species occurrences coloured by body size class in the Gulf of Lion"
-#| fig-height: 8
+#| fig-cap: "Interactive map of benthic species occurrences coloured by body size class, overlaid on seabed habitat polygons. Click on features for details."
 
-# Static map version for reliable rendering
-ggplot() +
-  geom_sf(data = med_countries, fill = "gray90", colour = "gray70") +
-  geom_sf(
-    data = occurrences_for_map,
-    aes(colour = size_class),
-    size = 1.5,
-    alpha = 0.6
+tmap_mode("view")
+
+interactive_map <- tm_shape(seabed_habitats) +
+  tm_polygons(
+    fill = "eunis2019c",
+    fill.scale = tm_scale_categorical(values = "Set3"),
+    fill.legend = tm_legend(title = "EUNIS Habitat"),
+    fill_alpha = 0.5,
+    col_alpha = 0
   ) +
-  scale_colour_viridis_d(option = "viridis", name = "Body size") +
-  coord_sf(
-    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
-    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
-  ) +
-  labs(
-    title = "Body Size Distribution Across the Gulf of Lion",
-    subtitle = sprintf("n = %d occurrences with trait data", nrow(occurrences_for_map))
-  ) +
-  theme_minimal() +
-  theme(legend.position = "bottom")
+  tm_shape(occurrences_for_map) +
+  tm_symbols(
+    fill = "size_class",
+    fill.scale = tm_scale_categorical(values = "viridis"),
+    fill.legend = tm_legend(title = "Body size"),
+    size = 0.1,
+    fill_alpha = 0.7,
+    popup.vars = c(
+      "Species" = "scientificname",
+      "Body length (mm)" = "max_length_mm",
+      "Habitat" = "EUNIS2019C",
+      "Biozone" = "biozone"
+    )
+  )
+
+# Save to standalone HTML to avoid pandoc hanging on large htmlwidgets
+tmap_save(interactive_map, get_output_path("biozone_bodysize_map.html", "tutorials"))
+
+knitr::include_url("biozone_bodysize_map.html", height = "600px")
 ```
 
 ## Discussion
 
 ### Key Findings
 
-This analysis demonstrates the integration of multiple EU marine data infrastructures to explore trait-environment relationships:
+This analysis demonstrates the integration of multiple EU marine data infrastructures to characterise benthic biozones in the Gulf of Lion:
 
-1. **Habitat associations**: Different seabed habitats support benthic communities with distinct body size distributions
-2. **Environmental gradients**: Body size shows variation along both depth and temperature gradients
-3. **Data integration**: Linking occurrence data to external trait databases and environmental layers substantially enriches analytical potential
+1.  **Habitat composition varies across biozones**: Shallow zones are dominated by sandy and coarse substrates, while deeper zones shift towards muddy sediments
+2.  **Environmental gradients structure biozones**: Depth and temperature covary with biozone, confirming that biozones capture meaningful environmental variation
+3.  **Body size shifts with depth**: Shallower biozones tend to support species with larger body sizes, with a shift towards smaller-bodied fauna in deeper zones
+4.  **Data integration**: Linking EMODnet occurrence and habitat data with Copernicus environmental layers and external trait databases enables multi-faceted ecological characterisation
 
 ### Ecological Interpretation
 
-The observed patterns may reflect several ecological processes:
+Biozones represent the vertical zonation of the seabed, reflecting gradients in light, pressure, temperature, and food supply. Our results are consistent with several ecological expectations:
 
-- **Environmental filtering**: Physical conditions in different habitats may favour certain body sizes
-- **Resource availability**: Habitat productivity and food supply influence what body sizes can be sustained
-- **Predation pressure**: Different habitats offer varying levels of refuge, potentially affecting body size distributions
+-   **Depth zonation**: The infralittoral and circalittoral zones, receiving more light and organic input, support diverse habitat types and substrates
+-   **Body size patterns**: The tendency for smaller body sizes at depth may reflect reduced food availability in deeper zones, consistent with Bergmann's rule inversions observed in some marine taxa
+-   **Substrate control**: Substrate composition changes with depth and hydrodynamic regime, shaping habitat availability
 
 However, these interpretations require caution:
 
-1. **Sampling bias**: Occurrence records may not represent true community composition
-2. **Taxonomic coverage**: MOBS trait data is incomplete, with smaller and less-studied taxa underrepresented
-3. **Spatial mismatch**: Environmental data resolution may not capture fine-scale heterogeneity
+1.  **Sampling bias**: Occurrence records may not represent true community composition, and shallow zones are typically better sampled
+2.  **Taxonomic coverage**: MOBS trait data is incomplete, with smaller and less-studied taxa underrepresented
+3.  **Spatial resolution**: Environmental data resolution may not capture fine-scale habitat heterogeneity
 
 ### Limitations
 
-- **Trait coverage**: Not all species in the occurrence data have body size records in MOBS
-- **Temporal mismatch**: Occurrence records span different time periods than environmental data
-- **Single trait focus**: Body size is just one dimension of functional diversity
+-   **Trait coverage**: Not all species in the occurrence data have body size records in MOBS, so body size patterns reflect a subset of the community
+-   **Temporal mismatch**: Occurrence records span different time periods than environmental data
+-   **Single region**: Patterns observed in the Gulf of Lion may not generalise to other Mediterranean basins with different oceanographic settings
 
 ### Extensions
 
 This workflow could be extended to:
 
-- Include additional traits (feeding mode, mobility, reproduction strategy)
-- Analyse temporal trends in trait composition
-- Model trait-environment relationships more formally
-- Compare patterns across regions
+-   Compare biozone characterisation across regions (e.g., Gulf of Lion vs Aegean Sea)
+-   Include additional traits from MOBS (feeding mode, mobility, reproduction strategy) for richer functional characterisation
+-   Analyse temporal trends in biozone composition
+-   Use the biozone framework to assess habitat condition or change over time
 
 ## What You've Learned
 
-This tutorial demonstrated advanced multi-source integration:
+This tutorial demonstrated advanced multi-source data integration:
 
-- **EMODnet WFS**: Accessing occurrence records and habitat polygons
-- **EMODnet WCS**: Retrieving bathymetry rasters
-- **Copernicus Marine Service**: Downloading oceanographic data
-- **External databases**: Linking to trait data via taxonomic identifiers
-- **Spatial operations**: Joins, extractions, and alignments across data types
-- **Trait-based analysis**: Exploring functional diversity across habitats
+-   **EMODnet WFS**: Accessing seabed habitat polygons and species occurrence records
+-   **EMODnet WCS**: Retrieving bathymetry rasters for zonal statistics
+-   **Copernicus Marine Service**: Downloading bottom temperature data
+-   **External databases**: Linking to body size trait data (MOBS) via taxonomic identifiers
+-   **Spatial operations**: Zonal statistics, CRS reprojection, and spatial joins across data types
+-   **Biozone characterisation**: Using biozones as an organising framework to synthesise habitat, environmental, and trait data
 
 These skills enable complex marine ecological analyses that draw on the full breadth of available EU marine data.
 
 ## Further Resources
 
-- [EMODnet Biology Portal](https://emodnet.ec.europa.eu/en/biology): Species occurrence data
-- [EMODnet Seabed Habitats Portal](https://emodnet.ec.europa.eu/en/seabed-habitats): Habitat maps
-- [Copernicus Marine Service](https://marine.copernicus.eu/): Oceanographic data
-- [World Register of Marine Species (WoRMS)](https://www.marinespecies.org/): Taxonomic backbone
-- [MOBS Database](https://github.com/crmcclain/MOBS_OPEN): Marine body size data
+-   [EMODnet Seabed Habitats Portal](https://emodnet.ec.europa.eu/en/seabed-habitats): Habitat maps
+-   [EMODnet Biology Portal](https://emodnet.ec.europa.eu/en/biology): Species occurrence data
+-   [Copernicus Marine Service](https://marine.copernicus.eu/): Oceanographic data
+-   [World Register of Marine Species (WoRMS)](https://www.marinespecies.org/): Taxonomic backbone
+-   [MOBS Database](https://github.com/crmcclain/MOBS_OPEN): Marine body size data
 
 ## References

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -1,6 +1,6 @@
 ---
 title: "4: Characterising Benthic Biozones"
-subtitle: "Combining Species Occurrences, Habitat Maps, Bathymetry, Temperature, and Body Size Data in the Gulf of Lion"
+subtitle: "Combining Habitat Maps, Bathymetry, Temperature, Species Occurrences and Body Size Data in the Gulf of Lion"
 difficulty: "Advanced"
 time: "~90 minutes"
 data-type: "WFS + WCS + External sources"
@@ -44,9 +44,11 @@ By the end of this tutorial, you will be able to:
 -   Download bathymetry rasters from EMODnet Bathymetry WCS
 -   Access bottom temperature data from the Copernicus Marine Service
 -   Link species records to body size data from external databases
--   Join datasets using shared identifiers (EUNIS codes, AphiaIDs)
+-   Use spatial joins to assign habitat and biozone attributes to species occurrences based on location
+-   Join datasets using shared identifiers (AphiaIDs)
 -   Extract zonal statistics from rasters using habitat polygons
 -   Characterise benthic biozones using habitat, environmental, and trait data
+-   Create interactive maps with the `leaflet` package
 
 ### Data Sources
 
@@ -92,7 +94,9 @@ library(ggplot2)
 library(ggridges)
 library(patchwork)
 library(tidyterra)
-library(tmap)
+library(leaflet)
+library(htmlwidgets)
+
 ```
 
 ```{r}
@@ -110,7 +114,8 @@ Most packages are available from CRAN:
 install.packages(c(
   "emodnet.wfs", "CopernicusMarine", "terra", "sf", "stars",
   "dplyr", "tidyr", "purrr", "readr", "stringr", "ggplot2",
-  "ggridges", "janitor", "patchwork", "tidyterra", "tmap",
+  "ggridges", "janitor", "patchwork", "tidyterra", "leaflet",
+  "htmlwidgets",
   "rnaturalearth"
 ))
 ```
@@ -125,16 +130,23 @@ pak::pak("EMODnet/emodnet.wcs")
 
 ### Study Area
 
-We focus on the Gulf of Lion in the northwestern Mediterranean. This region offers good coverage across most data sources involved, with diverse substrate types (sand, mud, coarse sediments, seagrass meadows) and spatial sampling across 165 unique locations. The Gulf of Lion also spans multiple biozones from infralittoral to bathyal depths:
+We focus on the Gulf of Lion in the northwestern Mediterranean. This region offers good coverage across most data sources involved, with diverse substrate types (sand, mud, coarse sediments, seagrass meadows) and spatial sampling across 165 unique locations. The Gulf of Lion also spans multiple biozones from infralittoral to bathyal depths.
+
+We start by defining a bounding box for our study area in WGS 84 (longitude/latitude degrees), which we will use to filter data downloads to this region. We also create an EPSG:3035 version, an equal-area projection that several of our data sources use (we discuss this CRS in more detail in the [spatial data integration](#spatial-data-integration) section):
 
 ```{r}
 #| label: define-study-area-bbox
-# Study area: Gulf of Lion for habitats and environmental data
-study_bbox <- c(xmin = 3, ymin = 42.5, xmax = 7, ymax = 44)
+# Study area bounding box in WGS 84 (degrees)
+study_bbox <- sf::st_bbox(
+  c(xmin = 3, ymin = 42.5, xmax = 7, ymax = 44),
+  crs = 4326
+)
+# As polygon geometries for visualisation and cropping
+bbox_polygon <- sf::st_as_sfc(study_bbox)
 
-# Create bbox polygon for visualisation (WGS 84) and spatial operations (EPSG:3035)
-bbox_polygon <- sf::st_as_sfc(sf::st_bbox(study_bbox, crs = 4326))
+# EPSG:3035 bbox and polygon
 bbox_polygon_3035 <- sf::st_transform(bbox_polygon, 3035)
+study_bbox_3035 <- sf::st_bbox(bbox_polygon_3035)
 ```
 
 ```{r}
@@ -147,7 +159,8 @@ med_countries <- rnaturalearth::ne_countries(
   scale = "medium",
   returnclass = "sf"
 ) |>
-  sf::st_crop(c(xmin = -2, ymin = 38, xmax = 12, ymax = 46))
+  sf::st_crop(c(xmin = -2, ymin = 38, xmax = 12, ymax = 46)) |>
+  sf::st_transform(3035)
 
 ggplot() +
   geom_sf(
@@ -157,7 +170,7 @@ ggplot() +
     linewidth = 0.3
   ) +
   geom_sf(data = bbox_polygon, fill = NA, color = "#004494", linewidth = 1.5) +
-  coord_sf(xlim = c(-2, 12), ylim = c(38, 46)) +
+  coord_sf(crs = 4326, xlim = c(-2, 12), ylim = c(38, 46)) +
   labs(x = NULL, y = NULL) +
   theme_minimal() +
   theme(panel.grid = element_line(color = "gray85", linewidth = 0.2))
@@ -212,6 +225,7 @@ habitat_attrs
 
 Key attributes include:
 
+-   **`geom`**: Geometry column. WFS layers can use different names for this column, so we extract it programmatically below to construct CQL bounding box filters
 -   **`eunis2019c`**: EUNIS 2019 habitat classification (level 3)
 -   **`eunis2019d`**: Human-readable EUNIS 2019 habitat description
 -   **`substrate`**: Seabed substrate type
@@ -239,11 +253,13 @@ eunis_values |>
   filter(.data[["."]] == "Na" | grepl("or", .data[["."]]))
 ```
 
-These are data gaps in the EUSeaMap product itself, not specific to our study area. Since these values are not valid EUNIS codes, they would cause problems in downstream joins. We filter them out server-side using CQL to avoid downloading polygons we cannot use.
+These are data gaps in the EUSeaMap product itself, not specific to our study area. Since these values are not valid EUNIS habitat classifications, we filter them out server-side using CQL to keep our habitat dataset clean.
 
 ### Building an Attribute CQL Filter
 
-We start by extracting the geometry column name for the BBOX filter:
+In previous tutorials we used CQL (Common Query Language) filters to spatially subset WFS data by bounding box. CQL can also filter on **attribute values**, which we use here for the first time to exclude the problematic `eunis2019c` entries identified above. We combine both spatial and attribute conditions into a single filter so the server only returns the data we need.
+
+We start by extracting the geometry column name for the [BBOX filter](tutorial-01.qmd#filtering-by-location-pre-download):
 
 ```{r}
 #| label: habitat-geom-col
@@ -254,8 +270,9 @@ We also want to combine the spatial BBOX filter with **attribute filters** to ex
 
 ```{r}
 #| label: habitat-cql-filter
-habitat_cql_filter <- sprintf(
-  "BBOX(%s, %s, %s, %s, %s, 'EPSG:4326') AND eunis2019c <> 'Na' AND eunis2019c NOT LIKE '%%or%%'",
+# Spatial filter: bounding box
+bbox_filter <- sprintf(
+  "BBOX(%s, %s, %s, %s, %s, 'EPSG:4326')",
   habitat_geom_col,
   study_bbox["xmin"],
   study_bbox["ymin"],
@@ -263,14 +280,20 @@ habitat_cql_filter <- sprintf(
   study_bbox["ymax"]
 )
 
+# Attribute filters: exclude invalid EUNIS codes
+na_filter <- "eunis2019c <> 'Na'"
+or_filter <- "eunis2019c NOT LIKE '%or%'"
+
+# Combine all conditions
+habitat_cql_filter <- paste(bbox_filter, na_filter, or_filter, sep = " AND ")
 habitat_cql_filter
 ```
 
-The `<>` operator excludes polygons where `eunis2019c` is exactly `"Na"`, and `NOT LIKE '%or%'` excludes any value containing the substring `"or"` (the `%` characters are CQL wildcards matching any sequence of characters). Note the `%%` in the `sprintf()` call: this is R's escape sequence to produce a literal `%` in the output string.
+The `<>` operator excludes polygons where `eunis2019c` is exactly `"Na"`, and `NOT LIKE '%or%'` excludes any value containing the substring `"or"` (the `%` characters are CQL wildcards matching any sequence of characters).
 
 ### Downloading Habitat Polygons
 
-Now we download with the combined spatial and attribute filter. The habitat layer's native CRS is Web Mercator (EPSG:3857), but we request **EPSG:3035** (ETRS89-extended / LAEA Europe) via `crs = 3035`. This is an [equal-area projection](../concepts.qmd#why-this-matters-for-marine-spatial-analysis) well suited to European marine data: every cell and polygon covers the same ground area regardless of latitude, which matters for zonal statistics and spatial joins later in the tutorial:
+Now we download with the combined spatial and attribute filter. We use [GeoJSON format](tutorial-01.qmd#why-use-geojson-format) (`outputFormat = "application/json"`) for faster downloads and simpler geometry types, and set `simplify = TRUE` to return a single `sf` data frame rather than a list of layers. The habitat layer's native CRS is Web Mercator (EPSG:3857), but we request **EPSG:3035** (ETRS89-extended / LAEA Europe) via `crs = 3035`. This is an [equal-area projection](../concepts.qmd#why-this-matters-for-marine-spatial-analysis) well suited to European marine data: every cell and polygon covers the same ground area regardless of latitude, which matters for zonal statistics and spatial joins later in the tutorial:
 
 ```{r}
 #| label: download-habitat-polygons
@@ -293,10 +316,11 @@ The WFS server returns any polygon that overlaps our bounding box, but it return
 
 ```{r}
 #| label: check-habitat-bbox
-st_bbox(seabed_habitats)
+# Transform to WGS 84 to show extent in degrees
+st_bbox(seabed_habitats) |> st_transform(4326)
 ```
 
-The extent is much larger than our study area (`r study_bbox["xmin"]`--`r study_bbox["xmax"]`°E, `r study_bbox["ymin"]`--`r study_bbox["ymax"]`°N). Leaving these oversized polygons in place causes two problems: it can skew analyses by including data outside the area of interest, and later, when we extract zonal statistics from rasters constrained to our bounding box, the overhanging parts of polygons produce `NaN` values (the raster has no cells to average over those areas).
+The extent (`r round(st_bbox(seabed_habitats) |> st_transform(4326))[c("xmin","xmax")] |> paste(collapse="--")`°E, `r round(st_bbox(seabed_habitats) |> st_transform(4326))[c("ymin","ymax")] |> paste(collapse="--")`°N) is much larger than our study area (`r study_bbox["xmin"]`--`r study_bbox["xmax"]`°E, `r study_bbox["ymin"]`--`r study_bbox["ymax"]`°N). Leaving these oversized polygons in place causes two problems: it can skew analyses by including data outside the area of interest, and later, when we extract zonal statistics from rasters constrained to our bounding box, the overhanging parts of polygons produce `NaN` values (the raster has no cells to average over those areas).
 
 We fix this with `sf::st_crop()`, which clips all geometries to a target rectangle. We use `bbox_polygon_3035`, the EPSG:3035 version of our study area polygon created at the start of the tutorial:
 
@@ -305,10 +329,10 @@ We fix this with `sf::st_crop()`, which clips all geometries to a target rectang
 seabed_habitats <- seabed_habitats |>
   st_crop(bbox_polygon_3035)
 
-st_bbox(seabed_habitats)
+st_bbox(seabed_habitats) |> st_transform(4326)
 ```
 
-The bounding box now matches our study area.
+The bounding box of our seabed habitat data now matches our study area.
 
 ### Inspecting Downloaded Data
 
@@ -325,14 +349,21 @@ seabed_habitats |>
 The WFS layer may use a different name for its geometry column (e.g. `the_geom`, `msGeometry`), but after download the `sf` package standardises the column name to `geometry`. This is normal and applies to all WFS downloads throughout this tutorial.
 :::
 
-The geometry column contains `sf MULTIPOLYGON` features. Each habitat feature is a polygon (or collection of polygons) delineating an area of seabed with a particular classification. The columns show:
+The geometry column contains sf `r unique(st_geometry_type(seabed_habitats))` features. Each habitat feature is a polygon (or collection of polygons) delineating an area of seabed with a particular classification. The columns show:
 
 - **`eunis2019c`**: the EUNIS 2019 level 3 code (e.g. `MB552`)
 - **`eunis2019d`**: the human-readable habitat description
 - **`substrate`**: the physical substrate (e.g. Sand, Mud, Coarse substrate)
 - **`biozone`**: the depth zone (e.g. Infralittoral, Deep circalittoral)
 
-The `biozone` variable represents depth zones from shallow (Infralittoral) to deep (Abyssal). We convert it to an ordered factor for meaningful analysis along depth gradients, and standardise `substrate` casing (the source data mixes "SAND" and "Sand"):
+The `biozone` variable represents depth zones from shallow (Infralittoral) to deep (Abyssal). 
+
+```{r}
+#| label: show-biozone
+unique(seabed_habitats$biozone)
+```
+
+We convert it to an ordered factor for meaningful analysis along depth gradients, and standardise `substrate` casing (the source data mixes "SAND" and "Sand"):
 
 ```{r}
 #| label: order-biozone
@@ -388,8 +419,14 @@ ggplot() +
     alpha = 0.8
   ) +
   coord_sf(
-    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
-    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
+    xlim = c(
+      study_bbox_3035["xmin"],
+      study_bbox_3035["xmax"]
+    ),
+    ylim = c(
+      study_bbox_3035["ymin"],
+      study_bbox_3035["ymax"]
+    )
   ) +
   scale_fill_viridis_d(option = "turbo", name = NULL) +
   labs(title = "Seabed Habitats (EUNIS 2019)") +
@@ -405,10 +442,10 @@ ggplot() +
 
 ## Retrieving Species Occurrence Data
 
-Next, we retrieve benthic species occurrence records from EMODnet Biology. These records have been matched to the World Register of Marine Species (WoRMS), ensuring taxonomic consistency, and each record is pre-matched to a EUNIS habitat code via the EUSeaMap grid, allowing us to link occurrences to the habitat polygons we just downloaded.
+Next, we retrieve benthic species occurrence records from EMODnet Biology. These are geolocated records whose species names have also been matched to the World Register of Marine Species (WoRMS) via an AphiaID code, ensuring taxonomic consistency. Later, we will use a spatial join to link these point occurrences to the habitat polygons we just downloaded, assigning each record to a habitat type, biozone and substrate based on where it falls on the seabed map.
 
 ::: {.callout-tip collapse="true"}
-## Taxonomic matching with the worrms package
+## Taxonomic matching with the `worrms` package
 
 The data we use here are already matched to WoRMS, but if you need to match your own species lists to the WoRMS taxonomic backbone, the [`worrms`](https://cran.r-project.org/package=worrms) R package provides a programmatic interface to WoRMS. It supports fuzzy name matching, retrieval of accepted names and synonyms, and lookup of taxonomic hierarchies, useful for standardising species names across datasets.
 :::
@@ -440,7 +477,7 @@ bio_layers |>
   knitr::kable()
 ```
 
-We choose `eb185_benthos_full_matched` because it contains individual occurrence records with coordinates, each matched to WoRMS (providing AphiaIDs we can use to link to trait data) and pre-matched to EUNIS habitat codes via the EUSeaMap grid. The `benthos_europe` layer, by contrast, provides gridded presence/absence summaries rather than individual occurrence records, so it is less suited to point-level analysis.
+We choose `eb185_benthos_full_matched` because it contains individual geolocated occurrence records, each matched to WoRMS (providing AphiaIDs we can use to link to trait data). The `benthos_europe` layer, by contrast, provides gridded presence/absence summaries rather than individual occurrence records, so it is less suited to point-level analysis.
 
 ### Understanding Layer Structure
 
@@ -459,24 +496,22 @@ benthos_attrs
 
 Key attributes for our analysis include:
 
--   **`st_point`**: Geometry column. We need to know this column name to construct spatial CQL filters (e.g. bounding box queries), so we extract it programmatically below
+-   **`st_point`**: Geometry column (extracted programmatically for the CQL filter, as with the habitat layer above)
 -   **`aphiaid`**: WoRMS identifier for linking to trait databases
 -   **`scientificname`**: Species name for display
 -   **`lon`**, **`lat`**: Coordinates
 -   **`year`**: Sampling year
 -   **`eusm_polygon_id`**: Link to the EUSeaMap grid polygon
--   **`EUNIS2019C`**, **`EUNIS2019D`**: EUNIS 2019 habitat classification (level 3 and 4), already matched via the EUSeaMap grid
+-   **`EUNIS2019C`**, **`EUNIS2019D`**: EUNIS 2019 habitat classification (level 3 and 4), pre-matched via the EUSeaMap grid. We will not use these for joining; instead we use a spatial join to assign habitat attributes based on where each occurrence falls within our habitat polygons
 
 ### Downloading Occurrence Data
 
-We use a [CQL BBOX filter](tutorial-01.qmd#filtering-by-location-pre-download) to request only records within our study area:
+As with the habitat data, we construct a CQL BBOX filter for our study area:
 
 ```{r}
 #| label: define-benthos-bbox-filter
-# Get the geometry column name
 benthos_geom_col <- benthos_attrs$name[benthos_attrs$geometry]
 
-# Create ECQL BBOX filter for study area
 benthos_bbox_filter <- sprintf(
   "BBOX(%s, %s, %s, %s, %s, 'EPSG:4326')",
   benthos_geom_col,
@@ -487,14 +522,7 @@ benthos_bbox_filter <- sprintf(
 )
 ```
 
-The resulting CQL filter combines the geometry column name with the `study_bbox` coordinates into a string that the WFS server interprets as a spatial constraint:
-
-```{r}
-#| label: print-benthos-bbox-filter
-benthos_bbox_filter
-```
-
-Now we download the data with `emodnet_get_layers()`, passing our CQL filter to restrict the query to the study area. As with the habitat data, we request EPSG:3035 so both vector datasets share the same equal-area CRS. We use [GeoJSON format](tutorial-01.qmd#why-use-geojson-format) (`outputFormat = "application/json"`) for faster downloads and simpler geometry types, and set `simplify = TRUE` to return a single `sf` data frame rather than a list of layers:
+Now we download the data with `emodnet_get_layers()`, passing our CQL filter to restrict the query to the study area. As with the habitat data, we use GeoJSON format and request EPSG:3035 so both vector datasets share the same equal-area CRS:
 
 ```{r}
 #| label: download-benthos-occurrences
@@ -514,20 +542,18 @@ nrow(benthos_occurrences)
 
 ### Inspecting Downloaded Data
 
-A quick preview of the data. Note the `sf POINT` geometry type in the geometry column: each occurrence is a single coordinate, in contrast to the habitat **polygons** we retrieved earlier:
+Each record is a geolocated `POINT` (in contrast to the habitat **polygons** we retrieved earlier), representing a species observed at a specific location and time. The key columns for our analysis are:
+
+-   **`aphiaid`**: WoRMS identifier, which we will use to link to body size data
+-   **`scientificname`**: Species name
+-   **`year`**: Sampling year
+-   **`geometry`**: Location of the observation
 
 ```{r}
 #| label: preview-benthos
 benthos_occurrences |>
-  select(aphiaid, scientificname, lon, lat, year, EUNIS2019C) |>
+  select(aphiaid, scientificname, year) |>
   head(10)
-```
-
-Each occurrence has been pre-matched to a EUNIS 2019 habitat code. Let's see which habitat types are represented and confirm the codes are clean:
-
-```{r}
-#| label: preview-benthos-eunis
-sort(unique(benthos_occurrences$EUNIS2019C))
 ```
 
 Let's examine the taxonomic diversity and data completeness:
@@ -561,12 +587,18 @@ ggplot() +
   geom_sf(
     data = benthos_occurrences,
     colour = "#0077BE",
-    size = 0.5,
+    size = 2,
     alpha = 0.3
   ) +
   coord_sf(
-    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
-    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
+    xlim = c(
+      study_bbox_3035["xmin"],
+      study_bbox_3035["xmax"]
+    ),
+    ylim = c(
+      study_bbox_3035["ymin"],
+      study_bbox_3035["ymax"]
+    )
   ) +
   labs(
     title = "Benthic Species Occurrences",
@@ -580,7 +612,7 @@ ggplot() +
 
 ## Retrieving Bathymetry Data
 
-Bathymetry (water depth) provides essential environmental context for our habitat characterisation. We retrieve this from EMODnet Bathymetry using [WCS](../concepts.qmd#wcs-web-coverage-service) (see [Tutorial 2](tutorial-02.qmd) for an introduction to working with the `emodnet.wcs` package).
+Bathymetry (water depth) provides essential environmental context for our habitat characterisation. Unlike the vector data (polygons and points) we have downloaded so far, bathymetry is served as **raster data**: a grid of cells where each cell holds a depth value. We retrieve this from EMODnet Bathymetry using [WCS](../concepts.qmd#wcs-web-coverage-service) (see [Tutorial 2](tutorial-02.qmd) for an introduction to working with the `emodnet.wcs` package).
 
 ### Connecting to EMODnet Bathymetry WCS
 
@@ -612,19 +644,18 @@ bathy_info |>
   knitr::kable()
 ```
 
-The resolution is approximately 1/960 of a degree (~115 m at this latitude), which is much finer than our bottom temperature raster (~4.2 km). This difference in resolution is one reason we extract zonal statistics from each raster separately later on.
+The resolution is approximately 1/960 of a degree (~115 m at this latitude). Note that the coverage CRS is EPSG:4326, which is why we pass `study_bbox` (our WGS 84 bounding box) when downloading. The nil value is `NA`, so no special handling of missing data codes is needed.
 
 ### Downloading Bathymetry
 
-We download the bathymetry raster for our study area using `emdn_get_coverage()`, which returns a `SpatRaster`. We set `nil_values_as_na = TRUE` so that any nil values declared in the coverage metadata (e.g. `-9999` for "no data") are converted to R's `NA`:
+We download the bathymetry raster for our study area using `emdn_get_coverage()`, which returns a `SpatRaster`:
 
 ```{r}
 #| label: download-bathymetry
 bathymetry <- emdn_get_coverage(
   wcs = bathy_wcs,
   coverage_id = "emodnet__mean_2022",
-  bbox = study_bbox,
-  nil_values_as_na = TRUE
+  bbox = study_bbox
 )
 
 bathymetry
@@ -639,11 +670,11 @@ EMODnet bathymetry uses the convention of **negative values for depth below sea 
 terra::global(bathymetry, range, na.rm = TRUE)
 ```
 
-The negative minimum confirms deep marine areas. The positive maximum (~1,900 m) may seem surprising for a marine study area, but our bounding box extends to 44°N, which reaches well inland over southern France into the foothills of the Pyrenees and Massif Central. EMODnet bathymetry is a digital terrain model that covers both sea and land, so these terrestrial elevations are included in the download. We set land cells (positive values) to `NA`, then negate the remaining values so that depth is expressed as a positive number (deeper = larger):
+The negative minimum confirms deep marine areas. The positive maximum (~1,900 m) may seem surprising for a marine study area, but our bounding box extends to 44°N, which reaches well inland over southern France into the foothills of the Pyrenees and Massif Central. EMODnet bathymetry is a digital terrain model that covers both sea and land, so these terrestrial elevations are included in the download. We set land and sea-level cells (values >= 0) to `NA`, then negate the remaining values so that depth is expressed as a positive number (deeper = larger):
 
 ```{r}
 #| label: process-bathymetry
-bathymetry[bathymetry > 0] <- NA
+bathymetry[bathymetry >= 0] <- NA
 depth <- -1 * bathymetry
 names(depth) <- "depth_m"
 ```
@@ -657,10 +688,9 @@ names(depth) <- "depth_m"
 
 ggplot() +
   geom_spatraster(data = depth) +
-  geom_sf(data = med_countries, fill = "gray40", colour = "gray30") +
   scale_fill_viridis_c(
     name = "Depth (m)",
-    na.value = "white",
+    na.value = "gray30",
     option = "mako",
     direction = -1,
     breaks = c(0, 200, 500, 1000, 2000, 2500),
@@ -672,10 +702,6 @@ ggplot() +
       to = c(0, 1),
       from = c(0, 2500)
     )
-  ) +
-  coord_sf(
-    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
-    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
   ) +
   labs(title = "Gulf of Lion Bathymetry") +
   theme_minimal() +
@@ -785,27 +811,27 @@ med_services |>
 
 All temperature layers contain `bottomT` (sea floor potential temperature) and `thetao` (potential temperature through the water column). For comprehensive documentation of all variable names, layer naming conventions, and production methodology, see the [Product User Manual (PUM)](https://documentation.marine.copernicus.eu/PUM/CMEMS-MED-PUM-006-004.pdf).
 
-We choose the monthly means layer (`P1M-m`) rather than daily (`P1D-m`) or climatology. Monthly data provides enough temporal resolution to compute a meaningful multi-year average while keeping the download size manageable. The climatology layer would seem ideal (it provides pre-computed long-term averages), but it has additional dimensions that the `CopernicusMarine` package cannot currently handle. Computing our own average from monthly data gives us full control over the time period.
+We choose the yearly means layer (`P1Y-m`) rather than daily (`P1D-m`) or monthly (`P1M-m`). The pre-computed climatology might seem ideal, but it provides a long-term average across all years, whereas we want to subset to the specific years when our species were sampled. Yearly means let us do exactly that while keeping the download small.
 
 ```{r}
 #| label: select-temp-layer
-# Select the monthly temperature layer
-temp_monthly <- med_services |>
-  filter(id == "cmems_mod_med_phy-temp_my_4.2km_P1M-m_202511")
+# Select the yearly temperature layer
+temp_yearly <- med_services |>
+  filter(id == "cmems_mod_med_phy-tem_my_4.2km_P1Y-m_202211")
 ```
 
 The `cube:dimensions` property tells us the available **temporal extent** and **time steps** for our chosen layer, which is essential for knowing what date range we can request:
 
 ```{r}
 #| label: check-temp-layer-time
-time_dim <- temp_monthly$properties[[1]]$`cube:dimensions`$time
+time_dim <- temp_yearly$properties[[1]]$`cube:dimensions`$time
 
 # Temporal extent (start and end dates)
 cat("Temporal extent:", time_dim$extent[[1]], "to", time_dim$extent[[2]])
 cat("Total time steps:", length(time_dim$values))
 ```
 
-The layer spans from 1987 to the present with monthly time steps. We now have all four pieces of information needed to download: the **product** ID, the **layer** ID (we choose monthly means, `P1M-m`), the **variable** ID (`bottomT`), and the available **time range**.
+The layer spans from 1987 to the present with yearly time steps. We now have all four pieces of information needed to download: the **product** ID (`MEDSEA_MULTIYEAR_PHY_006_004`), the **layer** ID (yearly means, `cmems_mod_med_phy-tem_my_4.2km_P1Y-m`), the **variable** ID (`bottomT`), and the available **time range**.
 
 ### Choosing a Time Period
 
@@ -825,7 +851,7 @@ ggplot(benthos_occurrences, aes(x = year)) +
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
 ```
 
-Sampling is concentrated in two periods: a large 1998 campaign and a main cluster from 2004 to 2018 with internal gaps. We download monthly temperature spanning 1998 to 2015, covering both periods while keeping the download small (~6 MB).
+Sampling is concentrated in two periods: a large 1998 campaign and a main cluster from 2004 to 2018 with internal gaps. We download yearly temperature spanning 1998 to 2018, covering both periods.
 
 ### Downloading Bottom Temperature
 
@@ -835,10 +861,10 @@ Sampling is concentrated in two periods: a large 1998 campaign and a main cluste
 #| label: download-bottom-temperature
 bottom_temp_stars <- cms_download_subset(
   product = "MEDSEA_MULTIYEAR_PHY_006_004",
-  layer = "cmems_mod_med_phy-temp_my_4.2km_P1M-m",
+  layer = "cmems_mod_med_phy-tem_my_4.2km_P1Y-m",
   variable = "bottomT",
   region = study_bbox,
-  timerange = c("1998-01-01", "2015-12-31")
+  timerange = c("1998-01-01", "2018-12-31")
 )
 ```
 
@@ -858,7 +884,7 @@ bottom_temp_stars
 stars::st_dimensions(bottom_temp_stars)
 ```
 
-Each monthly time step is a 2D spatial grid (longitude × latitude), and the full object stacks these along the time dimension. We can inspect the time values directly:
+Each yearly time step is a 2D spatial grid (longitude × latitude), and the full object stacks these along the time dimension. We can inspect the time values directly:
 
 ```{r}
 #| label: inspect-stars-time
@@ -870,7 +896,7 @@ cat("Last:", format(time_vals[length(time_vals)]))
 
 ### Filtering to Sampled Years
 
-Since our download spans 1998-2015 but not all years have occurrence data, we filter the time dimension to keep only months from years when sampling actually occurred. This gives a temperature mean that reflects the conditions organisms were experiencing.
+Since our download spans 1998-2018 but not all years have occurrence data, we filter the time dimension to keep only years when sampling actually occurred. This gives a temperature mean that reflects the conditions organisms were experiencing.
 
 ```{r}
 #| label: filter-stars-sampled-years
@@ -878,7 +904,7 @@ sampled_years <- unique(benthos_occurrences$year)
 keep <- as.integer(format(time_vals, "%Y")) %in% sampled_years
 bottom_temp_sampled <- bottom_temp_stars[,,, keep]
 
-cat("Retained", sum(keep), "of", length(keep), "monthly time steps")
+cat("Retained", sum(keep), "of", length(keep), "yearly time steps")
 cat("Years kept:", sort(unique(as.integer(format(time_vals[keep], "%Y")))))
 ```
 
@@ -886,7 +912,7 @@ cat("Years kept:", sort(unique(as.integer(format(time_vals[keep], "%Y")))))
 
 ### Computing the Mean Temperature
 
-`st_apply()` works like R's `apply()`: the first argument names the dimensions to **keep**, and the function is applied over all remaining dimensions. Here, `c("longitude", "latitude")` keeps the spatial dimensions and applies `mean` across time, collapsing all retained monthly time steps into a single 2D layer:
+`st_apply()` works like R's `apply()`: the first argument names the dimensions to **keep**, and the function is applied over all remaining dimensions. Here, `c("longitude", "latitude")` keeps the spatial dimensions and applies `mean` across time, collapsing all retained yearly time steps into a single 2D layer:
 
 ```{r}
 #| label: compute-mean-temperature
@@ -919,19 +945,14 @@ bottom_temp_mean
 ```{r}
 #| label: fig-bottom-temperature
 #| code-fold: true
-#| fig-cap: "Mean bottom temperature in the Gulf of Lion (sampled years, 1998-2015)"
+#| fig-cap: "Mean bottom temperature in the Gulf of Lion (sampled years, 1998-2018)"
 
 ggplot() +
   geom_spatraster(data = bottom_temp_mean) +
-  geom_sf(data = med_countries, fill = "gray40", colour = "gray30") +
   scale_fill_viridis_c(
     name = "Temperature (°C)",
-    na.value = "white",
+    na.value = "gray90",
     option = "turbo"
-  ) +
-  coord_sf(
-    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
-    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
   ) +
   labs(title = "Mean Bottom Temperature (sampled years)") +
   theme_minimal() +
@@ -957,11 +978,11 @@ The Marine Organism Body Size (MOBS) database provides body size measurements fo
 
 ### About MOBS
 
-The MOBS database [@mccallum2025] compiles body size data from literature sources, standardised to maximum body length where possible. This makes it ideal for linking to occurrence data that includes WoRMS identifiers (AphiaIDs).
+The MOBS database [@mccallum2025] compiles body size measurements (length, diameter/width, height) from literature sources for marine species, linked via WoRMS AphiaIDs. This makes it ideal for linking to occurrence data like ours.
 
 ### Loading MOBS Data
 
-The MOBS database is available as a CSV file on GitHub, which we can download directly with `readr::read_csv()`. The database uses WoRMS AphiaIDs as its species identifier (allowing us to join to our occurrence data) and stores body size measurements (length, diameter/width, height) in centimetres. We pipe the result through `janitor::clean_names()` to convert the mixed-case column names (e.g. `valid_aphiaID`, `scientificName`) to consistent snake_case.
+The MOBS database is available as a CSV file on GitHub, which we can download directly with `readr::read_csv()`. The database uses WoRMS AphiaIDs as its species identifier (allowing us to join to our occurrence data), stores body size measurements (length, diameter/width, height) in centimetres, and conveniently includes taxonomic classification (phylum, class, order, etc.). We pipe the result through `janitor::clean_names()` to convert the mixed-case column names (e.g. `valid_aphiaID`, `scientificName`) to consistent snake_case.
 
 ```{r}
 #| label: download-mobs
@@ -973,44 +994,49 @@ mobs_raw <- readr::read_csv(mobs_url, show_col_types = FALSE) |>
 head(mobs_raw, 10)
 ```
 
-We'll use the length measurement and convert from centimetres to millimetres. First, we filter MOBS to species present in our occurrence data, keeping only rows that have a length measurement (not all records do), convert units and select the columns we need:
+MOBS records body size using different measurements depending on the organism: length, diameter/width, or height. Rather than restricting to a single measurement type (which would lose entire taxonomic groups like Hydrozoa), we take the largest available linear dimension for each record as a general body size descriptor, and convert from centimetres to millimetres. We use `pmax()` (parallel maximum) to do this row-wise: unlike `max()` which returns a single value across all inputs, `pmax()` compares values across columns for each row and returns the largest, ignoring `NA`s. We then filter to species present in our occurrence data:
 
 ```{r}
 #| label: filter-mobs-to-occurrences
 occurrence_aphiaids <- unique(benthos_occurrences$aphiaid)
 
-mobs_filtered <- mobs_raw |>
-  filter(valid_aphia_id %in% occurrence_aphiaids, !is.na(length_cm)) |>
-  mutate(length_mm = length_cm * 10) |>
-  select(aphiaid = valid_aphia_id, scientific_name, length_mm, phylum, class)
+mobs <- mobs_raw |>
+  mutate(
+    body_size_mm = pmax(length_cm, diameter_width_cm, height_cm, na.rm = TRUE) *
+      10
+  ) |>
+  filter(valid_aphia_id %in% occurrence_aphiaids, !is.na(body_size_mm)) |>
+  select(aphiaid = valid_aphia_id, scientific_name, body_size_mm, phylum, class)
 
-cat("Rows matched:", nrow(mobs_filtered))
-cat("Unique species:", n_distinct(mobs_filtered$aphiaid))
-cat("Duplicated AphiaIDs:", sum(duplicated(mobs_filtered$aphiaid)))
+cat("Rows matched:", nrow(mobs))
+cat("Unique species:", n_distinct(mobs$aphiaid))
+cat("Duplicated AphiaIDs:", sum(duplicated(mobs$aphiaid)))
 ```
 
-Some species have multiple measurements from different literature sources. For our analysis we need a single value per species, so we take the maximum body length:
+Some species have multiple measurements from different literature sources. For our analysis we need a single value per species, so we take the maximum body size:
 
 ```{r}
 #| label: summarise-mobs-per-species
-mobs_matched <- mobs_filtered |>
+mobs <- mobs |>
   group_by(aphiaid, scientific_name, phylum, class) |>
-  summarise(max_length_mm = max(length_mm), .groups = "drop")
+  summarise(max_body_size_mm = max(body_size_mm), .groups = "drop")
+```
 
-n_matched <- nrow(mobs_matched)
-n_total <- length(occurrence_aphiaids)
+Since we filtered MOBS to species present in our occurrence data (via `occurrence_aphiaids`), we can check what proportion of our occurrence species have body size data:
 
+```{r}
+#| label: mobs-match-rate
 cat(sprintf(
-  "Matched %d of %d species (%.1f%%) to MOBS body size data",
-  n_matched,
-  n_total,
-  100 * n_matched / n_total
+  "Matched %d of %d occurrence species (%.1f%%) to MOBS body size data",
+  nrow(mobs),
+  length(occurrence_aphiaids),
+  100 * nrow(mobs) / length(occurrence_aphiaids)
 ))
 ```
 
 ```{r}
 #| label: preview-mobs-matched
-head(mobs_matched, 10)
+head(mobs, 10)
 ```
 
 ### Body Size Distribution
@@ -1020,13 +1046,13 @@ Let's examine the distribution of body sizes among our matched species:
 ```{r}
 #| label: fig-body-size-distribution
 #| code-fold: true
-#| fig-cap: "Distribution of maximum body length for Gulf of Lion benthic species with MOBS data (log scale)"
+#| fig-cap: "Distribution of maximum body size for Gulf of Lion benthic species with MOBS data (log scale)"
 
 n_bins <- 30
-log_range <- diff(range(log10(mobs_matched$max_length_mm)))
+log_range <- diff(range(log10(mobs$max_body_size_mm)))
 binwidth <- log_range / n_bins
 
-ggplot(mobs_matched, aes(x = max_length_mm)) +
+ggplot(mobs, aes(x = max_body_size_mm)) +
   geom_histogram(
     bins = n_bins,
     fill = "#0077BE",
@@ -1035,7 +1061,7 @@ ggplot(mobs_matched, aes(x = max_length_mm)) +
   ) +
   geom_density(
     aes(
-      y = after_stat(density) * nrow(mobs_matched) * binwidth,
+      y = after_stat(density) * nrow(mobs) * binwidth,
       colour = "Kernel density estimate"
     ),
     linewidth = 0.8,
@@ -1047,9 +1073,9 @@ ggplot(mobs_matched, aes(x = max_length_mm)) +
     title = "Body Size Distribution",
     subtitle = sprintf(
       "n = %d Gulf of Lion species with MOBS data",
-      nrow(mobs_matched)
+      nrow(mobs)
     ),
-    x = "Maximum body length (mm, log scale)",
+    x = "Maximum body size (mm, log scale)",
     y = "Number of species"
   ) +
   theme_minimal() +
@@ -1064,36 +1090,33 @@ The distribution is roughly log-normal with a median around 30 mm, but the densi
 #| fig-cap: "Body size distributions by taxonomic class for Gulf of Lion benthic species with MOBS length data (classes with fewer than 5 species excluded)"
 #| fig-height: 4
 
-class_counts <- mobs_matched |>
+class_counts <- mobs |>
   filter(!is.na(class)) |>
   count(class) |>
   filter(n >= 5) |>
   mutate(label = sprintf("%s (n = %d)", class, n))
 
-plot_data <- mobs_matched |>
+plot_data <- mobs |>
   inner_join(class_counts, by = "class") |>
-  mutate(label = reorder(label, max_length_mm, FUN = median))
+  mutate(label = reorder(label, max_body_size_mm, FUN = median))
 
-ggplot(plot_data, aes(x = label, y = max_length_mm)) +
+ggplot(plot_data, aes(x = label, y = max_body_size_mm)) +
   geom_violin(fill = "#0077BE", alpha = 0.5, colour = "white") +
-  geom_boxplot(width = 0.15, outlier.size = 0.8) +
+  geom_boxplot(width = 0.15, outlier.size = 0.8, alpha = 0.5) +
   scale_y_log10() +
   coord_flip() +
   labs(
     x = NULL,
-    y = "Maximum body length (mm, log scale)"
+    y = "Maximum body size (mm, log scale)"
   ) +
   theme_minimal()
 ```
 
-The first peak in the histogram is driven by malacostracan crustaceans (190 species, median ~10 mm), while the second reflects the larger polychaetes (231 species) and bivalves (132 species). Together these three classes make up over 90% of the matched species.
+The first peak in the histogram is driven by malacostracan crustaceans (`r sum(plot_data$class == "Malacostraca")` species), while the second reflects the larger polychaetes (`r sum(plot_data$class == "Polychaeta")` species) and bivalves (`r sum(plot_data$class == "Bivalvia")` species). Together these three classes make up `r round(100 * sum(plot_data$class %in% c("Malacostraca", "Polychaeta", "Bivalvia")) / nrow(mobs))`% of the matched species.
 
 ## Spatial Data Integration
 
-Now we bring our data sources together. The integration produces two datasets, each serving a different role in the biozone characterisation:
-
--   **Polygon level** (`habitat_env`): We compute environmental summaries (mean depth and temperature) for each habitat polygon, using the full set of polygons in the study area. This dataset characterises the biozones themselves: their habitat composition, substrate makeup, and environmental conditions.
--   **Occurrence level** (`occurrences_in_habitat`): We use `sf::st_join()` to spatially assign each species record to the habitat polygon it falls within, giving it that polygon's substrate and biozone. We also join body size data from MOBS via AphiaID. This dataset drives the body size analysis.
+Now we bring our data sources together. First, we enrich `seabed_habitats` with environmental summaries (mean depth and temperature) for each polygon. Then we create `benthos_joined` by using `sf::st_join()` to spatially assign each species record to the habitat polygon it falls within, giving it that polygon's substrate and biozone, and joining body size data from MOBS via AphiaID.
 
 ### Checking CRS Alignment
 
@@ -1116,12 +1139,11 @@ The vector datasets share EPSG:3035, so spatial joins will work directly. For th
 
 Rather than sampling a single centroid point per polygon, we compute **zonal statistics**, summarising all raster cells that fall within each habitat polygon. `terra::extract()` takes a raster and a set of polygons, identifies which raster cells fall within each polygon, and applies a summary function (here `mean`) across them. This captures the spatial extent of each habitat and produces more robust environmental characterisations, especially for large or irregularly shaped polygons. Depth and temperature have different native resolutions, so we extract each separately to avoid resampling.
 
-Because our habitat polygons are in EPSG:3035 (an [equal-area projection](../concepts.qmd#why-this-matters-for-marine-spatial-analysis)), we reproject the rasters to match before extraction. In an equal-area projection every raster cell covers the same ground area regardless of latitude, so each cell contributes equally to the mean:
+Spatial operations like calculating distances, areas, and zonal statistics require a projected coordinate system with linear units (metres), not geographic coordinates (degrees). In a geographic CRS like WGS 84, the ground distance represented by one degree of longitude varies with latitude, so calculations based on cell counts or coordinate differences will be distorted. An [equal-area projection](../concepts.qmd#why-this-matters-for-marine-spatial-analysis) like EPSG:3035, chosen to suit our European study area, ensures that every raster cell covers the same ground area, so each contributes equally to the mean. We reproject the rasters to match our habitat polygons before extraction:
 
 ```{r}
 #| label: extract-habitat-environment
-habitat_env <- seabed_habitats |>
-  st_drop_geometry() |>
+seabed_habitats <- seabed_habitats |>
   mutate(
     mean_depth_m = terra::extract(
       terra::project(depth, "EPSG:3035"),
@@ -1129,41 +1151,51 @@ habitat_env <- seabed_habitats |>
       fun = mean,
       na.rm = TRUE
     )$depth_m,
-    mean_temp_C = terra::extract(
+    mean_temp_c = terra::extract(
       terra::project(bottom_temp_mean, "EPSG:3035"),
       seabed_habitats,
       fun = mean,
       na.rm = TRUE
     )$bottom_temp_C
   )
+
+names(seabed_habitats)
 ```
 
-### Joining Occurrences to Habitats and Traits
+### Joining Occurrences to Habitat Polygons and Traits
 
-We combine the body size join (by AphiaID) and the spatial habitat join (by location) in a single pipeline. `inner_join()` retains only species with MOBS body size data, and `st_join()` assigns each occurrence to the habitat polygon it falls within, adding that polygon's `substrate` and `biozone`. Because both datasets are in EPSG:3035, the spatial join uses planar geometry directly:
+We combine the body size join (by AphiaID) and the spatial habitat polygon join (by geographic location) in a single pipeline.
+
+The first step uses `inner_join()`, a standard `dplyr` join that matches rows by shared values in a column (`aphiaid`). Unlike `left_join()` which keeps all rows from the left table, `inner_join()` only retains rows where the key exists in **both** tables. This means only occurrence records whose species also appear in MOBS (i.e. have body size data) are kept.
+
+Although the occurrence data already contains pre-matched EUNIS codes, we use a **spatial join** rather than joining on those codes. This is an important distinction: a join on EUNIS codes would associate each occurrence with every polygon sharing that habitat type, duplicating records across polygons where the species was never actually recorded. A spatial join instead links each occurrence to the specific polygon it falls within, preserving the actual environmental and habitat conditions in which it was recorded.
+
+We perform spatial joins with `sf::st_join()` which works differently from a standard `dplyr` join: instead of matching values in columns, it matches on **geometry**. For each point in the left dataset (occurrences), `st_join()` finds which polygon in the right dataset (habitat polygons) contains that point, and appends that polygon's attributes. The default spatial predicate is `st_intersects`, meaning a point is matched to any polygon it touches or falls inside. This is the spatial equivalent of `left_join()`: all rows from the left dataset are kept, and unmatched rows get `NA` for the joined columns. Because both datasets are in EPSG:3035, the spatial join uses planar geometry directly (no geographic coordinate warnings).
+
+We `select()` only `substrate` and `biozone` from the habitat polygons before joining, so only those columns are appended. Finally, we filter out any occurrences without a biozone value, keeping only records we can assign to a biozone for our characterisation:
 
 ```{r}
 #| label: join-occurrences-habitats-traits
-occurrences_in_habitat <- benthos_occurrences |>
-  inner_join(mobs_matched, by = "aphiaid") |>
+benthos_joined <- benthos_occurrences |>
+  inner_join(mobs, by = "aphiaid") |>
   st_join(select(seabed_habitats, substrate, biozone)) |>
   filter(!is.na(biozone))
 
 cat(sprintf(
   "Retained %d of %d occurrences (%.1f%%) with body size and habitat data",
-  nrow(occurrences_in_habitat),
+  nrow(benthos_joined),
   nrow(benthos_occurrences),
-  100 * nrow(occurrences_in_habitat) / nrow(benthos_occurrences)
+  100 * nrow(benthos_joined) / nrow(benthos_occurrences)
 ))
 ```
 
-A preview of the joined dataset, showing each occurrence with its species name, body size, habitat code, substrate, and biozone:
+A preview of the joined dataset, showing each occurrence with its species name, body size, EUNIS classification, substrate, and biozone:
 
 ```{r}
 #| label: preview-joined-occurrences
-occurrences_in_habitat |>
+benthos_joined |>
   st_drop_geometry() |>
-  select(scientificname, max_length_mm, EUNIS2019C, substrate, biozone) |>
+  select(scientificname, max_body_size_mm, EUNIS2019C, substrate, biozone) |>
   head(10)
 ```
 
@@ -1179,9 +1211,9 @@ Different EUNIS habitat types are distributed across biozones. Using the full se
 #| label: fig-habitat-by-biozone
 #| code-fold: true
 #| fig-cap: "Proportional EUNIS habitat type composition within each biozone"
-#| fig-height: 7
+#| fig-height: 9
 
-habitat_biozone_data <- habitat_env |>
+habitat_biozone_data <- seabed_habitats |>
   filter(!is.na(biozone), !is.na(eunis2019d)) |>
   count(biozone, eunis2019d)
 
@@ -1203,7 +1235,7 @@ ggplot(
   guides(fill = guide_legend(ncol = 2, override.aes = list(alpha = 1)))
 ```
 
-Habitat diversity decreases sharply with depth. The infralittoral supports the greatest variety of EUNIS habitat types (including Posidonia beds, rock, sand, and coarse sediment), and the shallow circalittoral retains several types (coralligène, coarse and mixed sediments, muddy detritic bottoms). From the deep circalittoral downwards, each biozone maps onto a single habitat type in our matched data, all mud-dominated.
+Habitat diversity varies across biozones. The infralittoral supports the greatest variety of EUNIS habitat types (including Posidonia beds, rock, sand, and coarse sediment). The shallow circalittoral retains several types (coralligène, coarse and mixed sediments, muddy detritic bottoms), while the deep circalittoral is dominated by a single detritic habitat. The bathyal zones show renewed diversity with rock, coarse sediment, mixed sediment, sand, and mud all represented, though mud becomes increasingly dominant. Only the abyssal maps onto a single habitat type (Mediterranean abyssal mud).
 
 ### Substrate Composition by Biozone
 
@@ -1215,7 +1247,7 @@ Substrate type (the physical material of the seabed) also varies with depth:
 #| fig-cap: "Proportional substrate composition within each biozone"
 #| fig-height: 5
 
-substrate_biozone_data <- habitat_env |>
+substrate_biozone_data <- seabed_habitats |>
   filter(!is.na(biozone), !is.na(substrate)) |>
   count(biozone, substrate)
 
@@ -1228,7 +1260,7 @@ ggplot(substrate_biozone_data, aes(x = biozone, y = n, fill = substrate)) +
   theme(axis.text.x = element_text(angle = 30, hjust = 1))
 ```
 
-Substrate composition also shows a clear transition with depth. The infralittoral is again the most diverse, featuring Posidonia meadows, coarse and mixed sediment, rock, and sand. The shallow and deep circalittoral retain a mix of substrates (sand, muddy sand, coarse sediment, fine mud), but fine mud becomes increasingly dominant. From the upper bathyal downwards, fine mud dominates all biozones, reaching 100% in the abyssal zone.
+Substrate composition also varies with depth. The infralittoral is the most diverse, featuring Posidonia meadows, coarse and mixed sediment, rock, sand, and dead mattes. Sand dominates the shallow circalittoral, giving way to muddy sand and fine mud in the deep circalittoral. The bathyal zones retain a mix of substrates (rock, muddy sand, sand, fine mud) with fine mud becoming increasingly prominent. The abyssal zone is entirely fine mud.
 
 ### Environmental Conditions by Biozone
 
@@ -1241,22 +1273,22 @@ Using the depth (EMODnet WCS) and bottom temperature (Copernicus Marine) data we
 #| fig-height: 4
 #| fig-width: 10
 
-env_data <- habitat_env |>
+env_data <- seabed_habitats |>
   filter(!is.na(biozone), !is.na(mean_depth_m))
 
 p_depth <- ggplot(env_data, aes(x = biozone, y = mean_depth_m)) +
   geom_violin(fill = "#0077BE", alpha = 0.5, colour = "white") +
-  geom_boxplot(width = 0.15, outlier.size = 0.8) +
+  geom_boxplot(width = 0.15, outlier.size = 0.8, alpha = 0.5) +
   labs(x = NULL, y = "Mean depth (m)") +
   theme_minimal() +
   theme(axis.text.x = element_text(angle = 30, hjust = 1))
 
 p_temp <- ggplot(
-  env_data |> filter(!is.na(mean_temp_C)),
-  aes(x = biozone, y = mean_temp_C)
+  env_data |> filter(!is.na(mean_temp_c)),
+  aes(x = biozone, y = mean_temp_c)
 ) +
   geom_violin(fill = "#E74C3C", alpha = 0.5, colour = "white") +
-  geom_boxplot(width = 0.15, outlier.size = 0.8) +
+  geom_boxplot(width = 0.15, outlier.size = 0.8, alpha = 0.5) +
   labs(x = NULL, y = "Mean bottom temperature (\u00b0C)") +
   theme_minimal() +
   theme(axis.text.x = element_text(angle = 30, hjust = 1))
@@ -1276,16 +1308,16 @@ Finally, we examine how body size varies across biozones. Ridge plots (from `ggr
 #| fig-cap: "Body size distribution by biozone"
 #| fig-height: 5
 
-biozone_plot_data <- occurrences_in_habitat |>
+biozone_plot_data <- benthos_joined |>
   st_drop_geometry() |>
-  filter(!is.na(biozone), !is.na(max_length_mm)) |>
+  filter(!is.na(biozone), !is.na(max_body_size_mm)) |>
   group_by(biozone) |>
   filter(n() >= 10) |>
   ungroup()
 
 ggplot(
   biozone_plot_data,
-  aes(x = max_length_mm, y = biozone)
+  aes(x = max_body_size_mm, y = fct_rev(biozone))
 ) +
   geom_density_ridges_gradient(
     aes(fill = after_stat(x)),
@@ -1296,16 +1328,17 @@ ggplot(
   scale_fill_viridis_c(
     name = "Body size (mm)",
     option = "plasma",
-    trans = "log10"
+    trans = "log10",
+    labels = scales::label_comma()
   ) +
   labs(
-    x = "Maximum body length (mm, log scale)",
+    x = "Maximum body size (mm, log scale)",
     y = "Biozone"
   ) +
   theme_minimal()
 ```
 
-The deeper biozones (lower bathyal, abyssal) are dominated by smaller-bodied species, while the shallower zones (infralittoral, circalittoral) show broader body size distributions extending to larger species. This pattern is consistent with the shift in taxonomic composition and environmental conditions across depth zones.
+Biozones with fewer than 10 records are excluded from the plot. The upper bathyal has too few records with body size data, and no occurrences fall within the abyssal zone. Among the remaining biozones, the lower bathyal is dominated by smaller-bodied species, while the shallower zones (infralittoral, circalittoral) show broader body size distributions extending to larger species. This pattern is consistent with the shift in taxonomic composition and environmental conditions across depth zones.
 
 We can break this down further by looking at taxonomic class within each biozone, using the same violin + boxplot approach as @fig-bodysize-by-class:
 
@@ -1316,9 +1349,9 @@ We can break this down further by looking at taxonomic class within each biozone
 #| fig-height: 8
 #| fig-width: 10
 
-class_biozone_data <- occurrences_in_habitat |>
+class_biozone_data <- benthos_joined |>
   st_drop_geometry() |>
-  filter(!is.na(biozone), !is.na(max_length_mm), !is.na(class)) |>
+  filter(!is.na(biozone), !is.na(max_body_size_mm), !is.na(class)) |>
   group_by(biozone) |>
   filter(n() >= 10) |>
   ungroup()
@@ -1331,70 +1364,124 @@ class_keep <- class_biozone_data |>
 
 class_biozone_data <- class_biozone_data |>
   semi_join(class_keep, by = "class") |>
-  mutate(class = reorder(class, max_length_mm, FUN = median))
+  mutate(class = reorder(class, max_body_size_mm, FUN = median))
 
-ggplot(class_biozone_data, aes(x = class, y = max_length_mm)) +
+ggplot(class_biozone_data, aes(x = class, y = max_body_size_mm)) +
   geom_violin(fill = "#0077BE", alpha = 0.5, colour = "white") +
-  geom_boxplot(width = 0.15, outlier.size = 0.5) +
+  geom_boxplot(width = 0.15, outlier.size = 0.5, alpha = 0.5) +
   scale_y_log10() +
   coord_flip() +
   facet_wrap(~biozone) +
   labs(
     x = NULL,
-    y = "Maximum body length (mm, log scale)"
+    y = "Maximum body size (mm, log scale)"
   ) +
   theme_minimal() +
   theme(strip.text = element_text(face = "bold"))
 ```
 
+Breaking body size down by taxonomic class within each biozone reveals which groups drive the overall patterns. The shallower biozones (infralittoral and shallow circalittoral) support the widest range of classes and body sizes. Malacostraca consistently appear as the smallest-bodied group across all biozones. The deeper biozones retain fewer classes, with polychaetes, bivalves, and malacostraca persisting into the deep circalittoral and lower bathyal while groups like anthozoa and echinoidea drop out.
+
 ## Interactive Map
 
-Let's create a map showing species occurrences coloured by body size class, overlaid on seabed habitats. We first bin continuous body lengths into discrete size classes using `cut()`:
+The plots above characterise each biozone in isolation. An interactive map brings these layers together spatially, letting you see where habitats, species occurrences, and body size classes are distributed across the Gulf of Lion. You can zoom into shelf features and submarine canyons, click individual occurrences for species details, and toggle habitat polygons on and off to explore spatial relationships that static plots cannot capture.
+
+In earlier tutorials we used `tmap` for interactive maps. Here we use the `leaflet` package, which provides a direct R interface to the [Leaflet.js](https://leafletjs.com/) library. While `tmap` is excellent for quick thematic maps, `leaflet` gives finer control over layer styling, pop-up content, and rendering behaviour, making it a valuable tool to have in your spatial analysis toolkit.
+
+Unlike `tmap`, `leaflet` requires all data in WGS 84 (EPSG:4326), so both layers need reprojecting with `st_transform()`. The habitat polygons also contain very detailed coastline and boundary geometry that is unnecessary for an overview map and slows down interactive rendering, so we additionally repair any invalid geometries with `st_make_valid()` (common in complex polygon datasets from web services) and reduce vertex counts with `st_simplify()`. The `dTolerance` parameter sets the maximum deviation in CRS units (here metres for EPSG:3035):
 
 ```{r}
-#| label: create-bodysize-classes
-# Create body size classes for visualisation
-occurrences_for_map <- occurrences_in_habitat |>
-  filter(!is.na(max_length_mm)) |>
+#| label: prepare-habitats-leaflet
+habitats_leaflet <- seabed_habitats |>
+  st_make_valid() |>
+  st_simplify(dTolerance = 200) |>
+  st_transform(4326)
+```
+
+For the occurrence points, we bin continuous body sizes into discrete size classes using `cut()`, creating categories that are easy to distinguish on a colour scale, and reproject to WGS 84:
+
+```{r}
+#| label: prepare-occurrences-leaflet
+benthos_leaflet <- benthos_joined |>
+  filter(!is.na(max_body_size_mm)) |>
   mutate(
     size_class = cut(
-      max_length_mm,
+      max_body_size_mm,
       breaks = c(0, 10, 50, 200, 1000, Inf),
       labels = c("<10mm", "10-50mm", "50-200mm", "200-1000mm", ">1000mm"),
       right = FALSE
     )
-  )
+  ) |>
+  st_transform(4326)
 ```
 
-The `tmap` package can produce interactive (Leaflet) maps with `tmap_mode("view")`. Here we layer habitat polygons under occurrence points, with pop-ups showing species name and traits:
+We build the map in layers. `addPolygons()` draws the habitat polygons, using `colorFactor()` to map EUNIS habitat codes to colours from the `"turbo"` palette. `addCircleMarkers()` overlays occurrence points coloured by body size class. Both layers include clickable pop-ups with relevant attributes:
 
 ```{r}
 #| label: fig-interactive-map
 #| eval: false
 
-tmap_mode("view")
+# Colour palettes
+habitat_pal <- colorFactor("turbo", domain = habitats_leaflet$eunis2019c)
+size_pal <- colorFactor("viridis", domain = benthos_leaflet$size_class)
 
-tm_shape(seabed_habitats) +
-  tm_polygons(
-    fill = "eunis2019c",
-    fill.scale = tm_scale_categorical(values = "Set3"),
-    fill.legend = tm_legend(title = "EUNIS Habitat"),
-    fill_alpha = 0.5,
-    col_alpha = 0
-  ) +
-  tm_shape(occurrences_for_map) +
-  tm_symbols(
-    fill = "size_class",
-    fill.scale = tm_scale_categorical(values = "viridis"),
-    fill.legend = tm_legend(title = "Body size"),
-    size = 0.1,
-    fill_alpha = 0.7,
-    popup.vars = c(
-      "Species" = "scientificname",
-      "Body length (mm)" = "max_length_mm",
-      "Habitat" = "EUNIS2019C",
-      "Biozone" = "biozone"
+leaflet() |>
+  addProviderTiles("Esri.WorldGrayCanvas") |>
+  addPolygons(
+    data = habitats_leaflet,
+    fillColor = ~ habitat_pal(eunis2019c),
+    fillOpacity = 0.5,
+    weight = 0,
+    smoothFactor = 0,
+    group = "Habitats",
+    popup = ~ paste0(
+      "<b>",
+      eunis2019d,
+      "</b><br>",
+      "<b>Biozone:</b> ",
+      biozone,
+      "<br>",
+      "<b>Substrate:</b> ",
+      substrate,
+      "<br>",
+      "<b>Mean depth (m):</b> ",
+      round(mean_depth_m, 1),
+      "<br>",
+      "<b>Mean bottom temp (\u00B0C):</b> ",
+      round(mean_temp_c, 1)
     )
+  ) |>
+  addCircleMarkers(
+    data = benthos_leaflet,
+    radius = 4,
+    fillColor = ~ size_pal(size_class),
+    fillOpacity = 0.7,
+    weight = 0.5,
+    color = "white",
+    group = "Occurrences",
+    popup = ~ paste0(
+      "<b>Species:</b> ",
+      scientificname,
+      "<br>",
+      "<b>Body size (mm):</b> ",
+      max_body_size_mm,
+      "<br>",
+      "<b>Habitat:</b> ",
+      EUNIS2019C,
+      "<br>",
+      "<b>Biozone:</b> ",
+      biozone
+    )
+  ) |>
+  addLegend(
+    pal = size_pal,
+    values = benthos_leaflet$size_class,
+    title = "Body size",
+    group = "Occurrences"
+  ) |>
+  addLayersControl(
+    overlayGroups = c("Habitats", "Occurrences"),
+    options = layersControlOptions(collapsed = FALSE)
   )
 ```
 
@@ -1403,36 +1490,82 @@ tm_shape(seabed_habitats) +
 #| echo: false
 #| fig-cap: "Interactive map of benthic species occurrences coloured by body size class, overlaid on seabed habitat polygons. Click on features for details."
 
-tmap_mode("view")
+# Colour palettes
+habitat_pal <- colorFactor("turbo", domain = habitats_leaflet$eunis2019c)
+size_pal <- colorFactor("viridis", domain = benthos_leaflet$size_class)
 
-interactive_map <- tm_shape(seabed_habitats) +
-  tm_polygons(
-    fill = "eunis2019c",
-    fill.scale = tm_scale_categorical(values = "Set3"),
-    fill.legend = tm_legend(title = "EUNIS Habitat"),
-    fill_alpha = 0.5,
-    col_alpha = 0
-  ) +
-  tm_shape(occurrences_for_map) +
-  tm_symbols(
-    fill = "size_class",
-    fill.scale = tm_scale_categorical(values = "viridis"),
-    fill.legend = tm_legend(title = "Body size"),
-    size = 0.1,
-    fill_alpha = 0.7,
-    popup.vars = c(
-      "Species" = "scientificname",
-      "Body length (mm)" = "max_length_mm",
-      "Habitat" = "EUNIS2019C",
-      "Biozone" = "biozone"
+interactive_map <- leaflet() |>
+  addProviderTiles("Esri.WorldGrayCanvas") |>
+  addPolygons(
+    data = habitats_leaflet,
+    fillColor = ~ habitat_pal(eunis2019c),
+    fillOpacity = 0.5,
+    weight = 0,
+    smoothFactor = 0,
+    group = "Habitats",
+    popup = ~ paste0(
+      "<b>",
+      eunis2019d,
+      "</b><br>",
+      "<b>Biozone:</b> ",
+      biozone,
+      "<br>",
+      "<b>Substrate:</b> ",
+      substrate,
+      "<br>",
+      "<b>Mean depth (m):</b> ",
+      round(mean_depth_m, 1),
+      "<br>",
+      "<b>Mean bottom temp (\u00B0C):</b> ",
+      round(mean_temp_c, 1)
     )
+  ) |>
+  addCircleMarkers(
+    data = benthos_leaflet,
+    radius = 4,
+    fillColor = ~ size_pal(size_class),
+    fillOpacity = 0.7,
+    weight = 0.5,
+    color = "white",
+    group = "Occurrences",
+    popup = ~ paste0(
+      "<b>Species:</b> ",
+      scientificname,
+      "<br>",
+      "<b>Body size (mm):</b> ",
+      max_body_size_mm,
+      "<br>",
+      "<b>Habitat:</b> ",
+      EUNIS2019C,
+      "<br>",
+      "<b>Biozone:</b> ",
+      biozone
+    )
+  ) |>
+  addLegend(
+    pal = size_pal,
+    values = benthos_leaflet$size_class,
+    title = "Body size",
+    group = "Occurrences"
+  ) |>
+  addLayersControl(
+    overlayGroups = c("Habitats", "Occurrences"),
+    options = layersControlOptions(collapsed = FALSE)
   )
 
 # Save to standalone HTML to avoid pandoc hanging on large htmlwidgets
-tmap_save(interactive_map, get_output_path("biozone_bodysize_map.html", "tutorials"))
+htmlwidgets::saveWidget(
+  interactive_map,
+  get_output_path("biozone_bodysize_map.html", "tutorials"),
+  selfcontained = TRUE
+)
 
 knitr::include_url("biozone_bodysize_map.html", height = "600px")
 ```
+
+The `popup` arguments use HTML strings to format the pop-up content. Tags like `<b>...</b>` for bold text and `<br>` for line breaks give control over how information is presented when a user clicks a feature. This is a key advantage of `leaflet` over `tmap`: full HTML support in pop-ups means you can style text, add links, or even embed images. See the [Leaflet for R documentation on popups and labels](https://rstudio.github.io/leaflet/articles/popups.html) for more examples.
+
+Note the `smoothFactor = 0` argument in `addPolygons()`. By default, Leaflet applies its own Douglas-Peucker simplification to polygon coordinates at render time to improve performance. For complex or concave polygons this can cause the simplified outline to cross itself, producing visible line artifacts across the polygon fill. Since we have already simplified the geometry server-side with `st_simplify()`, setting `smoothFactor = 0` disables this additional client-side step and avoids these artifacts.
 
 ## Discussion
 
@@ -1464,15 +1597,6 @@ However, these interpretations require caution:
 -   **Trait coverage**: Not all species in the occurrence data have body size records in MOBS, so body size patterns reflect a subset of the community
 -   **Temporal mismatch**: Occurrence records span different time periods than environmental data
 -   **Single region**: Patterns observed in the Gulf of Lion may not generalise to other Mediterranean basins with different oceanographic settings
-
-### Extensions
-
-This workflow could be extended to:
-
--   Compare biozone characterisation across regions (e.g., Gulf of Lion vs Aegean Sea)
--   Include additional traits from MOBS (feeding mode, mobility, reproduction strategy) for richer functional characterisation
--   Analyse temporal trends in biozone composition
--   Use the biozone framework to assess habitat condition or change over time
 
 ## What You've Learned
 

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -890,6 +890,9 @@ Each yearly time step is a 2D spatial grid (longitude × latitude), and the full
 ```{r}
 #| label: inspect-stars-time
 time_vals <- stars::st_get_dimension_values(bottom_temp_stars, "time")
+# Ensure consistent POSIXct format (stars may return units objects
+# depending on the data source and platform)
+time_vals <- as.POSIXct(time_vals)
 cat("Time steps:", length(time_vals))
 cat("First:", format(time_vals[1]))
 cat("Last:", format(time_vals[length(time_vals)]))

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -138,7 +138,7 @@ pak::pak("EMODnet/emodnet.wcs")
 
 We focus on the Gulf of Lion in the northwestern Mediterranean. This region offers good coverage across most data sources involved, with diverse substrate types (sand, mud, coarse sediments, seagrass meadows) and spatial sampling across 165 unique locations. The Gulf of Lion also spans multiple biozones from infralittoral to bathyal depths.
 
-We start by defining a bounding box for our study area in WGS 84 (longitude/latitude degrees), chosen to cover the continental shelf and slope of the Gulf of Lion from roughly Nice to Perpignan. We will use this to filter data downloads to this region. We also create an EPSG:3035 (ETRS89-extended / LAEA Europe) version, an equal-area projection that several of our data sources use (we discuss this CRS in more detail in the [spatial data integration](#spatial-data-integration) section):
+We start by defining a bounding box for our study area in WGS 84 (longitude/latitude degrees), chosen to cover the continental shelf and slope of the Gulf of Lion from roughly Nice to Perpignan. We will use this to filter data downloads to this region. We also create an EPSG:3035 (ETRS89-extended / LAEA Europe) version. This is an [equal-area projection](../concepts.qmd#why-this-matters-for-marine-spatial-analysis) well suited to European marine data: every cell and polygon covers the same ground area regardless of latitude, which is important for accurate zonal statistics and spatial joins. For this reason, we will be working in this CRS throughout the tutorial. Where possible, we will download data directly in EPSG:3035; where not, we will reproject to it before analysis (we discuss this in more detail in the [spatial data integration](#spatial-data-integration) section):
 
 ```{r}
 #| label: define-study-area-bbox
@@ -212,7 +212,7 @@ habitat_layers |>
   select(layer_name, title)
 ```
 
-The results show separate layers for energy, substrate, biozone, and two habitat classification systems (EUNIS 2007 and EUNIS 2019). We choose `eusm2025_eunis2019_full` because EUNIS 2019 is the current classification standard and this layer includes both the habitat code and the substrate and biozone attributes we need.
+The results show separate layers for energy, substrate, biozone, and two habitat classification systems (EUNIS 2007 and EUNIS 2019). We choose `eusm2025_eunis2019_full` because EUNIS 2019 is the more recent classification standard and this layer includes both the habitat code and the substrate and biozone attributes we need.
 
 ### Understanding Habitat Classifications
 
@@ -232,7 +232,7 @@ habitat_attrs
 
 Key attributes include:
 
--   **`geom`**: Geometry column (the only row with `geometry = TRUE`). WFS layers can use different names for this column, so we extract it programmatically below to construct CQL bounding box filters
+-   **`geom`**: Geometry column (the only row with `geometry = TRUE`). WFS layers can use different names for this column, so we extract it programmatically below to construct [CQL (Common Query Language)](tutorial-01.qmd#filtering-by-location-pre-download) bounding box filters
 -   **`eunis2019c`**: EUNIS 2019 habitat classification (level 3)
 -   **`eunis2019d`**: Human-readable EUNIS 2019 habitat description
 -   **`substrate`**: Seabed substrate type
@@ -300,7 +300,7 @@ The `<>` operator excludes polygons where `eunis2019c` is exactly `"Na"`, and `N
 
 ### Downloading Habitat Polygons
 
-Now we download with the combined spatial and attribute filter. We use [GeoJSON format](tutorial-01.qmd#why-use-geojson-format) (`outputFormat = "application/json"`) for faster downloads and simpler geometry types, and set `simplify = TRUE` to return a single `sf` data frame rather than a list of layers. The habitat layer's native CRS is Web Mercator (EPSG:3857), but we request **EPSG:3035** (ETRS89-extended / LAEA Europe) via `crs = 3035`. This is an [equal-area projection](../concepts.qmd#why-this-matters-for-marine-spatial-analysis) well suited to European marine data: every cell and polygon covers the same ground area regardless of latitude, which matters for zonal statistics and spatial joins later in the tutorial:
+Now we download with the combined spatial and attribute filter. We use [GeoJSON format](tutorial-01.qmd#why-use-geojson-format) (`outputFormat = "application/json"`) for faster downloads and simpler geometry types, and set `simplify = TRUE` to return a single `sf` data frame rather than a list of layers. The habitat layer's native CRS is Web Mercator (EPSG:3857), but we request **EPSG:3035** via `crs = 3035`, the equal-area projection introduced above:
 
 ```{r}
 #| label: download-habitat-polygons
@@ -741,7 +741,7 @@ Because the data is multi-dimensional, `cms_download_subset()` returns a [`stars
 
 The metadata returned by `CopernicusMarine` functions follows the STAC specification. For a general introduction to what STAC is and how catalogues, collections, and items relate, see the [STAC intro tutorial](https://stacspec.org/en/tutorials/intro-to-stac/). In practice, the deeply nested metadata structures can be challenging to navigate, but contain rich information about layers, variables, dimensions, and time ranges, as we explore below.
 
-The discovery workflow follows a similar pattern to EMODnet: list what is available, inspect metadata, then download a subset.
+The discovery workflow follows a similar pattern to EMODnet: list what is available, inspect metadata, then download a subset. For more on data discovery, see the CopernicusMarine vignettes on [product information](https://pepijn-devries.github.io/CopernicusMarine/articles/product-info.html) and [translating from the Copernicus Marine toolbox](https://pepijn-devries.github.io/CopernicusMarine/articles/translate.html).
 
 ### Choosing a Data Product
 
@@ -761,7 +761,7 @@ A Copernicus **product** plays the same role as an EMODnet **service** (like `"b
 
 ### Browsing Available Variables
 
-Unlike OGC services where each layer contains a single dataset, Copernicus products are built on a datacube architecture. A single product can bundle multiple physical variables (temperature, salinity, currents) across multiple layers. We can get a high-level overview of all variables available across the entire product using `cms_product_details()`:
+Unlike OGC services where each layer contains a single dataset, Copernicus products are built on a datacube architecture. A single product can bundle multiple physical variables (temperature, salinity, currents) across multiple layers, where each layer can have distinct dimensions. We can get a high-level overview of all variables available across the entire product using `cms_product_details()`:
 
 ```{r}
 #| label: explore-med-product-details
@@ -863,7 +863,7 @@ Sampling is concentrated in two periods: a large 1998 campaign and a main cluste
 
 ### Downloading Bottom Temperature
 
-`cms_download_subset()` returns a [`stars`](../concepts.qmd#stars---spatiotemporal-arrays) object (a multi-dimensional array). Note that the `timerange` dates must match the layer's time steps, which as we saw above are indexed to January 1st of each year:
+`cms_download_subset()` returns a [`stars`](../concepts.qmd#stars---spatiotemporal-arrays) object (a multi-dimensional array). The `timerange` specifies the date range to download; any time steps falling within this range will be included:
 
 ```{r}
 #| label: download-bottom-temperature
@@ -872,7 +872,7 @@ bottom_temp_stars <- cms_download_subset(
   layer = "cmems_mod_med_phy-tem_my_4.2km_P1Y-m",
   variable = "bottomT",
   region = study_bbox,
-  timerange = c("1998-01-01", "2018-01-01")
+  timerange = c("1998-01-01", "2018-12-31")
 )
 ```
 
@@ -933,18 +933,20 @@ bottom_temp_mean <- bottom_temp_sampled |>
 
 ### Converting Stars to Terra Raster
 
-The rest of our analysis uses `terra` for raster operations (zonal statistics, extraction). To convert from `stars` to a `terra` `SpatRaster`, we need to address a grid compatibility issue: the Copernicus Marine grid is **rectilinear** (cell spacing along longitude and latitude is not perfectly uniform), but `terra::rast()` requires a **regular** grid with uniform cell sizes.
+The rest of our analysis uses `terra` for raster operations (zonal statistics, extraction). To convert from `stars` to a `terra` `SpatRaster`, we need to regularise the grid: `stars` stores the Copernicus Marine grid as a list of cell boundaries rather than as a regular "start + step size" definition, and `terra::rast()` only accepts the latter.
 
-`stars::st_warp()` resamples a `stars` object onto a target grid. We build that target with `stars::st_as_stars()`, passing `sf::st_bbox(bottom_temp_mean)` to preserve the original spatial extent and setting `dx` and `dy` to 1/24° to match the native Copernicus Marine resolution (~4.2 km at this latitude):
+`stars::st_warp()` resamples onto a regular target grid. We build it with `stars::st_as_stars()`, which takes a bounding box and a cell size (`dx`, `dy`) and produces a regular grid. We derive the cell size from the data's extent and number of cells to preserve the native resolution. Note that the target grid inherits its CRS from the bounding box of the source data; the reprojection to our shared EPSG:3035 CRS happens later when we compute zonal statistics:
 
 ```{r}
 #| label: convert-to-terra
+# Derive native cell size from extent and number of cells
+dims <- stars::st_dimensions(bottom_temp_mean)
+temp_bbox <- sf::st_bbox(bottom_temp_mean)
+dx <- as.numeric((temp_bbox["xmax"] - temp_bbox["xmin"]) / dims[["longitude"]]$to)
+dy <- as.numeric((temp_bbox["ymax"] - temp_bbox["ymin"]) / dims[["latitude"]]$to)
+
 bottom_temp_mean <- bottom_temp_mean |>
-  stars::st_warp(stars::st_as_stars(
-    sf::st_bbox(bottom_temp_mean),
-    dx = 1 / 24,
-    dy = 1 / 24
-  )) |>
+  stars::st_warp(stars::st_as_stars(temp_bbox, dx = dx, dy = dy)) |>
   terra::rast()
 names(bottom_temp_mean) <- "bottom_temp_C"
 
@@ -1228,13 +1230,24 @@ Different EUNIS habitat types are distributed across biozones. Using the full se
 
 habitat_biozone_data <- seabed_habitats |>
   filter(!is.na(biozone), !is.na(eunis2019d)) |>
-  count(biozone, eunis2019d)
+  count(biozone, eunis2019c, eunis2019d) |>
+  group_by(biozone) |>
+  mutate(prop = n / sum(n)) |>
+  ungroup() |>
+  mutate(label = if_else(prop >= 0.08, eunis2019c, ""))
 
 ggplot(
   habitat_biozone_data,
   aes(x = biozone, y = n, fill = str_wrap(eunis2019d, width = 50))
 ) +
-  geom_bar(stat = "identity", position = "fill") +
+  geom_bar(stat = "identity", position = "fill", colour = "white", linewidth = 0.3) +
+  geom_text(
+    aes(label = label),
+    position = position_fill(vjust = 0.5),
+    colour = "white",
+    size = 3.5,
+    fontface = "bold"
+  ) +
   scale_fill_viridis_d(option = "turbo", direction = -1, name = NULL) +
   scale_y_continuous(labels = scales::percent) +
   labs(x = "Biozone", y = "Proportion of polygons") +
@@ -1435,7 +1448,7 @@ We build the map in layers. `addPolygons()` draws the habitat polygons, using `c
 #| eval: false
 
 # Colour palettes
-habitat_pal <- colorFactor("turbo", domain = habitats_leaflet$eunis2019c)
+habitat_pal <- colorFactor("turbo", domain = habitats_leaflet$eunis2019c, reverse = TRUE)
 size_pal <- colorFactor("viridis", domain = benthos_leaflet$size_class)
 
 leaflet() |>
@@ -1504,7 +1517,7 @@ leaflet() |>
 #| fig-cap: "Interactive map of benthic species occurrences coloured by body size class, overlaid on seabed habitat polygons. Click on features for details."
 
 # Colour palettes
-habitat_pal <- colorFactor("turbo", domain = habitats_leaflet$eunis2019c)
+habitat_pal <- colorFactor("turbo", domain = habitats_leaflet$eunis2019c, reverse = TRUE)
 size_pal <- colorFactor("viridis", domain = benthos_leaflet$size_class)
 
 interactive_map <- leaflet() |>
@@ -1580,6 +1593,12 @@ The `popup` arguments use HTML strings to format the pop-up content. Tags like `
 
 Note the `smoothFactor = 0` argument in `addPolygons()`. By default, Leaflet applies its own Douglas-Peucker simplification to polygon coordinates at render time to improve performance. For complex or concave polygons this can cause the simplified outline to cross itself, producing visible line artifacts across the polygon fill. Since we have already simplified the geometry server-side with `st_simplify()`, setting `smoothFactor = 0` disables this additional client-side step and avoids these artifacts.
 
+::: {.callout-tip collapse="true"}
+## Adding Copernicus Marine tile layers
+
+The `CopernicusMarine` package can add WMTS tile layers directly to leaflet maps using [`addCmsWMTSTiles()`](https://pepijn-devries.github.io/CopernicusMarine/reference/addCmsWMTSTiles.html). This is useful for overlaying Copernicus Marine data (e.g. sea surface temperature, chlorophyll) as background layers without downloading the data first.
+:::
+
 ## Discussion
 
 ### Key Findings
@@ -1631,5 +1650,8 @@ These skills enable complex marine ecological analyses that draw on the full bre
 -   [Copernicus Marine Service](https://marine.copernicus.eu/): Oceanographic data
 -   [World Register of Marine Species (WoRMS)](https://www.marinespecies.org/): Taxonomic backbone
 -   [MOBS Database](https://github.com/crmcclain/MOBS_OPEN): Marine body size data
+-   [`sf` package](https://r-spatial.github.io/sf/): Simple features for R
+-   [`terra` package](https://rspatial.github.io/terra/): Spatial data analysis with rasters and vectors
+-   [`stars` package](https://r-spatial.github.io/stars/): Spatiotemporal arrays
 
 ## References

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -1300,7 +1300,7 @@ Depth increases steadily across biozones as expected, from near-surface in the i
 
 ### Body Size Distributions by Biozone
 
-Finally, we examine how body size varies across biozones. Ridge plots (from `ggridges`) show kernel density estimates stacked vertically, with fill colour mapped to body size. `scale` controls how much adjacent ridges overlap (0.9 keeps them mostly separate), and `rel_min_height` trims density tails below 1% of the peak to avoid long, thin artefacts:
+Finally, we examine how body size varies across biozones. Ridge plots (from [`ggridges`](https://wilkelab.org/ggridges/)) show kernel density estimates stacked vertically, with fill colour mapped to body size. `scale` controls how much adjacent ridges overlap (0.9 keeps them mostly separate), and `rel_min_height` trims density tails below 1% of the peak to avoid long, thin artefacts:
 
 ```{r}
 #| label: fig-bodysize-by-biozone
@@ -1386,7 +1386,7 @@ Breaking body size down by taxonomic class within each biozone reveals which gro
 
 The plots above characterise each biozone in isolation. An interactive map brings these layers together spatially, letting you see where habitats, species occurrences, and body size classes are distributed across the Gulf of Lion. You can zoom into shelf features and submarine canyons, click individual occurrences for species details, and toggle habitat polygons on and off to explore spatial relationships that static plots cannot capture.
 
-In earlier tutorials we used `tmap` for interactive maps. Here we use the `leaflet` package, which provides a direct R interface to the [Leaflet.js](https://leafletjs.com/) library. While `tmap` is excellent for quick thematic maps, `leaflet` gives finer control over layer styling, pop-up content, and rendering behaviour, making it a valuable tool to have in your spatial analysis toolkit.
+In earlier tutorials we used `tmap` for interactive maps. Here we use the [`leaflet`](https://rstudio.github.io/leaflet/) package, which provides a direct R interface to the [Leaflet.js](https://leafletjs.com/) library. While `tmap` is excellent for quick thematic maps, `leaflet` gives finer control over layer styling, pop-up content, and rendering behaviour, making it a valuable tool to have in your spatial analysis toolkit.
 
 Unlike `tmap`, `leaflet` requires all data in WGS 84 (EPSG:4326), so both layers need reprojecting with `st_transform()`. The habitat polygons also contain very detailed coastline and boundary geometry that is unnecessary for an overview map and slows down interactive rendering, so we additionally repair any invalid geometries with `st_make_valid()` (common in complex polygon datasets from web services) and reduce vertex counts with `st_simplify()`. The `dTolerance` parameter sets the maximum deviation in CRS units (here metres for EPSG:3035):
 

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -864,10 +864,8 @@ bottom_temp_stars <- cms_download_subset(
   product = "MEDSEA_MULTIYEAR_PHY_006_004",
   layer = "cmems_mod_med_phy-tem_my_4.2km_P1Y-m",
   variable = "bottomT",
-  region = study_bbox
-  # TODO: restore timerange when
-  # https://github.com/pepijn-devries/CopernicusMarine/issues/164 is fixed
-  # timerange = c("1998-01-01", "2018-01-01")
+  region = study_bbox,
+  timerange = c("1998-01-01", "2018-01-01")
 )
 ```
 
@@ -892,9 +890,6 @@ Each yearly time step is a 2D spatial grid (longitude × latitude), and the full
 ```{r}
 #| label: inspect-stars-time
 time_vals <- stars::st_get_dimension_values(bottom_temp_stars, "time")
-# Ensure consistent POSIXct format (stars may use different time
-# reference systems depending on the data source and platform)
-time_vals <- as.POSIXct(time_vals)
 cat("Time steps:", length(time_vals))
 cat("First:", format(time_vals[1]))
 cat("Last:", format(time_vals[length(time_vals)]))

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -864,8 +864,10 @@ bottom_temp_stars <- cms_download_subset(
   product = "MEDSEA_MULTIYEAR_PHY_006_004",
   layer = "cmems_mod_med_phy-tem_my_4.2km_P1Y-m",
   variable = "bottomT",
-  region = study_bbox,
-  timerange = c("1998-01-01", "2018-01-01")
+  region = study_bbox
+  # TODO: restore timerange when
+  # https://github.com/pepijn-devries/CopernicusMarine/issues/164 is fixed
+  # timerange = c("1998-01-01", "2018-01-01")
 )
 ```
 

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -1,38 +1,1409 @@
 ---
 title: "4: Functional Traits Across Seabed Habitats"
-subtitle: "Exploring Functional Traits Across Seabed Habitats in the Aegean Sea"
+subtitle: "Integrating EMODnet Data with Trait and Environmental Data Sources in the Gulf of Lion"
 difficulty: "Advanced"
 time: "~90 minutes"
 data-type: "WFS + WCS + External sources"
-description: "Integrate EMODnet data with external trait databases and Copernicus Marine Service environmental data. Investigate how benthic species body size varies across habitat types and environmental gradients in the Aegean Sea."
-datasets: "Benthic species occurrences, seabed habitat maps, trait databases, temperature reanalysis data"
+description: "Learn to integrate EMODnet WFS and WCS services with external data sources including the Copernicus Marine Service and trait databases. Investigate how benthic species body size varies across seabed habitat types and environmental gradients in the Gulf of Lion."
+datasets: "Benthic species occurrences, seabed habitat polygons, bathymetry, bottom temperature, body size traits"
+df-print: paged
+bibliography: references.bib
+format:
+  html:
+    embed-resources: false
+    code-link: true
 ---
 
-## Tutorial Content
+## Introduction
 
-This tutorial is currently under development.
+The Gulf of Lion, located in the northwestern Mediterranean off the coast of southern France, hosts a rich diversity of benthic communities shaped by the Rhône River delta, diverse substrates from sandy beaches to deep canyons, and strong environmental gradients. Understanding how functional traits like body size vary across these habitats can reveal patterns of community assembly and environmental filtering that underpin ecosystem function.
 
-### What You'll Learn
+In this tutorial, we demonstrate how to **integrate multiple EU marine data infrastructures** to explore trait-environment relationships in benthic communities. We combine:
 
-- Demonstrating combined use of emodnet.wfs, emodnet.wcs, and CopernicusMarine packages
-- Retrieving and visualising body size traits for benthic species using trait databases
-- Exploring trait–environment relationships across habitat types
-- Practical geospatial workflows including raster extraction and spatial joins
+- **EMODnet WFS** for species occurrence records and habitat maps
+- **EMODnet WCS** for bathymetry data
+- **Copernicus Marine Service** for bottom temperature
+- **MOBS database** for species body size traits
+
+This multi-source approach reflects real-world marine ecological analysis, where insights emerge from combining data across platforms and domains.
+
+### Why Body Size?
+
+Body size is a fundamental trait linked to metabolism, feeding strategy, life history, and ecological role. Larger organisms generally have lower mass-specific metabolic rates, longer lifespans, and different trophic positions than smaller organisms. The distribution of body sizes in a community can reveal patterns of:
+
+- **Environmental filtering**: Temperature and depth gradients may favour certain body size ranges
+- **Habitat associations**: Different seabed types may support communities with distinct size structures
+- **Community function**: Body size distributions affect energy flow and ecosystem processes
+
+### Learning Objectives
+
+By the end of this tutorial, you will be able to:
+
+- Access benthic species occurrence data from EMODnet Biology WFS
+- Retrieve seabed habitat polygons from EMODnet Seabed Habitats WFS
+- Download bathymetry rasters from EMODnet Bathymetry WCS
+- Access bottom temperature data from the Copernicus Marine Service
+- Link species records to body size traits from external databases
+- Perform spatial joins between points and polygons
+- Extract raster values to point locations
+- Visualise trait-environment relationships across habitat types
 
 ### Data Sources
 
-- **EMODnet WFS:**
-  - `eb185_benthos_full_matched`: Benthic species records in the Aegean
-  - `eu_seabed_habitats_2019`: Seabed habitat polygons
-- **EMODnet WCS:**
-  - `emodnet__mean_2020`: Bathymetry raster (mean depth of seafloor)
-- **Copernicus Marine Service:**
-  - `GLOBAL_MULTIYEAR_PHY_001_030`: Bottom temperature and/or salinity reanalysis data
-- **External Resources:**
-  - **MOBS (Marine Organism Body Size) database**: [github.com/crmcclain/MOBS_OPEN](https://github.com/crmcclain/MOBS_OPEN)
+**EMODnet WFS (Vector Data):**
+
+| Layer | Service | Description |
+|-------|---------|-------------|
+| `eb185_benthos_full_matched` | biology | Benthic species occurrence records from European seas |
+| `eusm_2023_eunis2019_full` | seabed_habitats_general_datasets_and_products | EU Seabed Map with EUNIS 2019 classification |
+
+**EMODnet WCS (Raster Data):**
+
+| Coverage | Service | Description |
+|----------|---------|-------------|
+| `emodnet__mean_2020` | bathymetry | Mean water depth (bathymetry) |
+
+**External Sources:**
+
+| Source | Description |
+|--------|-------------|
+| [Copernicus Marine Service](https://marine.copernicus.eu/) | Bottom temperature from GLOBAL_MULTIYEAR_PHY_001_030 reanalysis |
+| [MOBS Database](https://github.com/crmcclain/MOBS_OPEN) | Marine Organism Body Size database [@mccallum2025] |
+
+## Setup
+
+### Packages
+
+This tutorial uses a broader set of packages than previous tutorials, reflecting the multi-source integration workflow:
+
+```{r}
+#| label: load-packages
+#| message: false
+library(emodnet.wfs)
+library(emodnet.wcs)
+library(CopernicusMarine)
+library(terra)
+library(sf)
+library(dplyr)
+library(tidyr)
+library(purrr)
+library(ggplot2)
+library(patchwork)
+library(tidyterra)
+library(tmap)
+```
+
+```{r}
+#| label: setup
+#| include: false
+# Set PROJ path if needed (for coordinate transformations)
+if (
+  Sys.getenv("PROJ_LIB") == "" &&
+    file.exists("/opt/homebrew/share/proj/proj.db")
+) {
+  Sys.setenv(PROJ_LIB = "/opt/homebrew/share/proj")
+}
+
+# Load package data and helper functions
+library(emodnet.bio.r.geo.tutorials)
+```
+
+::: {.callout-tip collapse="true"}
+## Package installation
+
+Most packages are available from CRAN:
+
+```r
+install.packages(c(
+  "terra", "sf", "dplyr", "tidyr", "purrr",
+  "ggplot2", "tidyterra", "tmap", "rnaturalearth"
+))
+```
+
+For the EMODnet packages (development versions from GitHub):
+
+```r
+# install.packages("pak")
+pak::pak(c("EMODnet/emodnet.wfs", "EMODnet/emodnet.wcs"))
+```
+
+For the Copernicus Marine Service package:
+
+```r
+pak::pak("pepijn-devries/CopernicusMarine")
+```
+
+**Note:** The CopernicusMarine package requires you to register for a free account at [marine.copernicus.eu](https://marine.copernicus.eu/) and configure your credentials. See the [package documentation](https://pepijn-devries.github.io/CopernicusMarine/) for setup instructions.
+:::
 
 ### Study Area
 
-Aegean Sea
+We focus on the Gulf of Lion in the northwestern Mediterranean. This region offers excellent data coverage with diverse substrate types (sand, mud, coarse sediments, seagrass meadows) and good spatial sampling across 165 unique locations. The Gulf of Lion also spans multiple biozones from infralittoral to bathyal depths:
 
-Check back soon for the complete tutorial!
+```{r}
+#| label: define-study-area-bbox
+# Study area: Gulf of Lion for habitats and environmental data
+study_bbox <- c(xmin = 3, ymin = 41, xmax = 7, ymax = 44)
+
+# Create bbox polygon for visualisation
+bbox_polygon <- sf::st_as_sfc(sf::st_bbox(study_bbox, crs = 4326))
+```
+
+```{r}
+#| label: fig-study-area
+#| echo: false
+#| fig-cap: "Study area: Gulf of Lion in the northwestern Mediterranean"
+
+# Get Mediterranean coastlines
+med_countries <- rnaturalearth::ne_countries(
+  scale = "medium",
+  returnclass = "sf"
+) |>
+  sf::st_crop(c(xmin = -2, ymin = 38, xmax = 12, ymax = 46))
+
+ggplot() +
+  geom_sf(data = med_countries, fill = "gray90", color = "gray60", linewidth = 0.3) +
+  geom_sf(data = bbox_polygon, fill = NA, color = "#0077BE", linewidth = 1.5) +
+  coord_sf(xlim = c(-2, 12), ylim = c(38, 46)) +
+  labs(x = NULL, y = NULL) +
+  theme_minimal() +
+  theme(panel.grid = element_line(color = "gray85", linewidth = 0.2))
+```
+
+## Retrieving Species Occurrence Data
+
+Our first data source is benthic species occurrence records from EMODnet Biology. The Gulf of Lion has excellent coverage with over 16,000 records from 165 sampling locations, providing a rich species pool for trait analysis. These records have been matched to the World Register of Marine Species (WoRMS), ensuring taxonomic consistency.
+
+### Connecting to EMODnet Biology WFS
+
+```{r}
+#| label: init-biology-wfs
+bio_wfs <- emodnet_init_wfs_client(service = "biology")
+```
+
+### Exploring Available Layers
+
+Let's search for benthic occurrence data:
+
+```{r}
+#| label: explore-biology-layers
+#| cache: true
+bio_layers <- emodnet_get_wfs_info(bio_wfs)
+
+# Filter for benthos-related layers
+bio_layers |>
+  filter(grepl("benthos", layer_name, ignore.case = TRUE)) |>
+  select(layer_name, title)
+```
+
+The `eb185_benthos_full_matched` layer contains benthic occurrence records that have been matched to WoRMS, providing standardised species identifications with AphiaIDs (unique WoRMS identifiers).
+
+### Understanding Layer Structure
+
+Before downloading, let's examine what attributes are available:
+
+```{r}
+#| label: inspect-benthos-attributes
+#| cache: true
+benthos_attrs <- layer_attribute_descriptions(
+  wfs = bio_wfs,
+  layer = "eb185_benthos_full_matched"
+)
+
+benthos_attrs
+```
+
+Key attributes for our analysis include:
+
+- **`aphiaid`**: WoRMS identifier for linking to trait databases
+- **`scientificname`**: Species name for display
+- **`lon`**, **`lat`**: Coordinates
+- **`year`**: Sampling year
+
+### Downloading Occurrence Data
+
+We use a CQL filter to request records from the Gulf of Lion study area:
+
+```{r}
+#| label: define-benthos-bbox-filter
+# Get the geometry column name
+benthos_geom_col <- benthos_attrs$name[benthos_attrs$geometry]
+
+# Create ECQL BBOX filter for study area
+benthos_bbox_filter <- sprintf(
+  "BBOX(%s, %s, %s, %s, %s, 'EPSG:4326')",
+  benthos_geom_col,
+  study_bbox["xmin"],
+  study_bbox["ymin"],
+  study_bbox["xmax"],
+  study_bbox["ymax"]
+)
+```
+
+```{r}
+#| label: download-benthos-occurrences
+#| cache: true
+benthos_occurrences <- emodnet_get_layers(
+  wfs = bio_wfs,
+  layers = "eb185_benthos_full_matched",
+  cql_filter = benthos_bbox_filter,
+  outputFormat = "application/json",
+  simplify = TRUE
+)
+
+# Check the result
+nrow(benthos_occurrences)
+```
+
+```{r}
+#| label: preview-benthos
+benthos_occurrences |>
+  select(aphiaid, scientificname, lon, lat, year) |>
+  head(10)
+```
+
+### Data Quality Check
+
+Let's examine the taxonomic diversity and data completeness:
+
+```{r}
+#| label: benthos-summary
+# How many unique species?
+n_species <- n_distinct(benthos_occurrences$aphiaid)
+
+# How many records have valid AphiaIDs for trait matching?
+n_with_aphiaid <- sum(!is.na(benthos_occurrences$aphiaid))
+
+cat(sprintf(
+  "Total records: %d\nUnique species (AphiaIDs): %d\nRecords with valid AphiaID: %d (%.1f%%)\n",
+  nrow(benthos_occurrences),
+  n_species,
+  n_with_aphiaid,
+  100 * n_with_aphiaid / nrow(benthos_occurrences)
+))
+```
+
+### Quick Visualisation
+
+```{r}
+#| label: fig-benthos-occurrences
+#| fig-cap: "Benthic species occurrence records in the Gulf of Lion"
+
+ggplot() +
+  geom_sf(data = med_countries, fill = "gray90", colour = "gray70") +
+  geom_sf(
+    data = benthos_occurrences,
+    colour = "#0077BE",
+    size = 0.5,
+    alpha = 0.3
+  ) +
+  coord_sf(
+    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
+    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
+  ) +
+  labs(
+    title = "Benthic Species Occurrences",
+    subtitle = sprintf("%d records in the Gulf of Lion", nrow(benthos_occurrences))
+  ) +
+  theme_minimal()
+```
+
+## Retrieving Seabed Habitat Data
+
+Next, we retrieve seabed habitat polygons to classify our occurrence records by habitat type.
+
+### Connecting to EMODnet Seabed Habitats WFS
+
+```{r}
+#| label: init-habitats-wfs
+hab_wfs <- emodnet_init_wfs_client(service = "seabed_habitats_general_datasets_and_products")
+```
+
+### Exploring Habitat Layers
+
+```{r}
+#| label: explore-habitat-layers
+#| cache: true
+hab_layers <- emodnet_get_wfs_info(hab_wfs)
+
+# Search for EU seabed habitat layers
+hab_layers |>
+  filter(grepl("eu.*seabed|seabed.*habitat", layer_name, ignore.case = TRUE)) |>
+  select(layer_name, title)
+```
+
+### Understanding Habitat Classifications
+
+Let's examine the attribute structure of the habitat layer:
+
+```{r}
+#| label: inspect-habitat-attributes
+#| cache: true
+habitat_attrs <- layer_attribute_descriptions(
+  wfs = hab_wfs,
+  layer = "eusm_2023_eunis2019_full"
+)
+
+habitat_attrs
+```
+
+Key attributes include:
+
+- **`eunis2019c`**: EUNIS 2019 habitat classification (level 3)
+- **`eunis2019d`**: EUNIS 2019 habitat classification (level 4, more detailed)
+- **`substrate`**: Seabed substrate type
+- **`biozone`**: Biological zone
+
+Let's check what habitat values are present:
+
+```{r}
+#| label: explore-habitat-types
+#| cache: true
+layer_attribute_inspect(
+  wfs = hab_wfs,
+  layer = "eusm_2023_eunis2019_full",
+  attribute = "eunis2019c"
+)
+```
+
+### Downloading Habitat Polygons
+
+```{r}
+#| label: download-habitat-polygons
+#| cache: true
+# Get geometry column name
+habitat_geom_col <- habitat_attrs$name[habitat_attrs$geometry]
+
+# Create BBOX filter
+habitat_bbox_filter <- sprintf(
+  "BBOX(%s, %s, %s, %s, %s, 'EPSG:4326')",
+  habitat_geom_col,
+  study_bbox["xmin"],
+  study_bbox["ymin"],
+  study_bbox["xmax"],
+  study_bbox["ymax"]
+)
+
+seabed_habitats <- emodnet_get_layers(
+  wfs = hab_wfs,
+  layers = "eusm_2023_eunis2019_full",
+  cql_filter = habitat_bbox_filter,
+  outputFormat = "application/json",
+  simplify = TRUE
+)
+
+# Convert biozone to ordered factor (shallow to deep)
+biozone_levels <- c(
+ "Infralittoral",
+ "Shallow circalittoral",
+  "Deep circalittoral",
+  "Upper bathyal",
+  "Lower bathyal",
+  "Abyssal"
+)
+
+seabed_habitats <- seabed_habitats |>
+  mutate(biozone = factor(biozone, levels = biozone_levels, ordered = TRUE))
+
+nrow(seabed_habitats)
+```
+
+The `biozone` variable represents depth zones from shallow (Infralittoral) to deep (Abyssal), which we convert to an ordered factor for meaningful analysis along depth gradients.
+
+```{r}
+#| label: habitat-type-summary
+# Summarise habitat types present
+seabed_habitats |>
+  st_drop_geometry() |>
+  count(eunis2019c, sort = TRUE) |>
+  head(10)
+```
+
+### Visualising Seabed Habitats
+
+```{r}
+#| label: fig-seabed-habitats
+#| fig-cap: "Seabed habitat classification in the Gulf of Lion (EUNIS 2019). Colours represent different EUNIS habitat codes."
+#| fig-height: 6
+#| fig-width: 8
+
+ggplot() +
+  geom_sf(data = med_countries, fill = "gray90", colour = "gray70") +
+
+  geom_sf(
+    data = seabed_habitats,
+    aes(fill = eunis2019c),
+    colour = NA,
+    alpha = 0.8
+  ) +
+  coord_sf(
+    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
+    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
+  ) +
+  scale_fill_viridis_d(option = "turbo") +
+  labs(title = "Seabed Habitats (EUNIS 2019)") +
+  theme_minimal() +
+  theme(legend.position = "none")
+```
+
+The map shows the spatial distribution of EUNIS 2019 habitat types across the Gulf of Lion. The diversity of colours reflects the variety of seabed habitats present, from shallow coastal sediments to deeper muddy substrates. Rather than listing all `r n_distinct(seabed_habitats$eunis2019c)` habitat codes in a legend, we summarise the main habitat categories below:
+
+## Retrieving Bathymetry Data
+
+Bathymetry (water depth) provides essential environmental context. We retrieve this from EMODnet Bathymetry using WCS.
+
+### Connecting to EMODnet Bathymetry WCS
+
+```{r}
+#| label: init-bathymetry-wcs
+bathy_wcs <- emdn_init_wcs_client(service = "bathymetry")
+```
+
+### Exploring Available Coverages
+
+```{r}
+#| label: list-bathymetry-coverages
+bathy_coverage_ids <- emdn_get_coverage_ids(bathy_wcs)
+bathy_coverage_ids
+```
+
+We'll use the mean depth product:
+
+```{r}
+#| label: get-bathymetry-info
+bathy_info <- emdn_get_coverage_info(
+  wcs = bathy_wcs,
+  coverage_ids = "emodnet__mean_2020"
+)
+
+bathy_info |>
+  knitr::kable()
+```
+
+### Downloading Bathymetry
+
+The full-resolution bathymetry data can be quite large, so we download it in tiles and mosaic them together:
+
+```{r}
+#| label: download-bathymetry
+# Split the bbox into smaller tiles to avoid download limits
+# Create a 2x2 grid of tiles
+lon_breaks <- seq(study_bbox["xmin"], study_bbox["xmax"], length.out = 3)
+lat_breaks <- seq(study_bbox["ymin"], study_bbox["ymax"], length.out = 3)
+
+# Download each tile
+tiles <- list()
+tile_idx <- 1
+for (i in 1:2) {
+  for (j in 1:2) {
+    tile_bbox <- c(
+      xmin = lon_breaks[i],
+      ymin = lat_breaks[j],
+      xmax = lon_breaks[i + 1],
+      ymax = lat_breaks[j + 1]
+    )
+    tiles[[tile_idx]] <- emdn_get_coverage(
+      wcs = bathy_wcs,
+      coverage_id = "emodnet__mean_2020",
+      bbox = tile_bbox
+    )
+    tile_idx <- tile_idx + 1
+  }
+}
+
+# Combine tiles into a SpatRasterCollection and merge
+tiles_collection <- terra::sprc(tiles)
+bathymetry <- terra::merge(tiles_collection)
+bathymetry
+```
+
+Note that EMODnet bathymetry values are typically **negative** (depth below sea level). Let's verify and convert to positive depth values for easier interpretation:
+
+```{r}
+#| label: process-bathymetry
+# Check value range
+global(bathymetry, range, na.rm = TRUE)
+
+# Convert to positive depth values
+depth <- -1 * bathymetry
+names(depth) <- "depth_m"
+```
+
+### Visualising Bathymetry
+
+```{r}
+#| label: fig-bathymetry
+#| fig-cap: "Bathymetry of the Gulf of Lion (depth in metres)"
+
+ggplot() +
+  geom_spatraster(data = depth) +
+  geom_sf(data = med_countries, fill = "gray40", colour = "gray30") +
+  scale_fill_viridis_c(
+    name = "Depth (m)",
+    na.value = "white",
+    option = "mako",
+    direction = -1
+  ) +
+  coord_sf(
+    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
+    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
+  ) +
+  labs(title = "Gulf of Lion Bathymetry") +
+  theme_minimal() +
+  theme(legend.position = "bottom")
+```
+
+## Retrieving Bottom Temperature
+
+Bottom temperature provides insight into thermal niches and may influence body size distributions. We access this from the [Copernicus Marine Service](https://marine.copernicus.eu/) using the [`CopernicusMarine`](https://pepijn-devries.github.io/CopernicusMarine/) R package.
+
+### Understanding the Data Product
+
+We use the GLOBAL_MULTIYEAR_PHY_001_030 product, which provides ocean reanalysis data including bottom temperature. Let's explore what's available:
+
+```{r}
+#| label: explore-copernicus-products
+#| cache: true
+# List available products
+cms_products_list() |>
+  filter(grepl("GLOBAL_MULTIYEAR_PHY", product_id)) |>
+  select(product_id, title)
+```
+
+### Downloading Bottom Temperature
+
+We download bottom temperature for our study area. The `cms_download_subset()` function returns a `stars` object that we can convert to a `terra` raster:
+
+```{r}
+#| label: download-bottom-temperature
+# Download bottom temperature subset
+# This returns a stars object directly into memory
+bottom_temp_stars <- cms_download_subset(
+  product = "GLOBAL_MULTIYEAR_PHY_001_030",
+  layer = "cmems_mod_glo_phy_my_0.083deg_P1M-m",
+  variable = "bottomT",
+  region = study_bbox,
+  timerange = c("2020-01-01", "2020-12-31")
+)
+
+# The stars object may have multiple time slices - aggregate to mean
+# Use stars functions to handle the aggregation properly
+if ("time" %in% names(stars::st_dimensions(bottom_temp_stars))) {
+  bottom_temp_mean_stars <- stars::st_apply(
+    bottom_temp_stars,
+    c("longitude", "latitude"),
+    mean,
+    na.rm = TRUE
+  )
+} else {
+  bottom_temp_mean_stars <- bottom_temp_stars
+}
+
+# Convert to terra raster using sf as intermediate
+# First drop units if present
+bottom_temp_mean_stars[[1]] <- as.numeric(bottom_temp_mean_stars[[1]])
+
+# Convert via sf
+bottom_temp_sf <- sf::st_as_sf(bottom_temp_mean_stars, as_points = TRUE)
+bottom_temp_mean <- terra::rasterize(
+  terra::vect(bottom_temp_sf),
+  terra::rast(
+    extent = terra::ext(
+      study_bbox["xmin"], study_bbox["xmax"],
+      study_bbox["ymin"], study_bbox["ymax"]
+    ),
+    resolution = 0.083,  # ~8km resolution matching the data
+    crs = "EPSG:4326"
+  ),
+  field = names(bottom_temp_sf)[1]
+)
+names(bottom_temp_mean) <- "bottom_temp_C"
+
+# Quick check
+bottom_temp_mean
+```
+
+### Visualising Bottom Temperature
+
+```{r}
+#| label: fig-bottom-temperature
+#| fig-cap: "Mean annual bottom temperature in the Gulf of Lion (2020)"
+
+ggplot() +
+  geom_spatraster(data = bottom_temp_mean) +
+  geom_sf(data = med_countries, fill = "gray40", colour = "gray30") +
+  scale_fill_viridis_c(
+    name = "Temperature (°C)",
+    na.value = "white",
+    option = "inferno"
+  ) +
+  coord_sf(
+    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
+    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
+  ) +
+  labs(title = "Bottom Temperature (2020 mean)") +
+  theme_minimal() +
+  theme(legend.position = "bottom")
+```
+
+::: {.callout-tip collapse="true"}
+## Finding available products and layers
+
+Use `cms_products_list()` to browse available products and `cms_product_details()` to explore layers within a product:
+```r
+# List all products
+products <- cms_products_list()
+
+# Get details for a specific product
+cms_product_details("GLOBAL_MULTIYEAR_PHY_001_030")
+```
+:::
+
+::: {.callout-note collapse="true"}
+## Working with Copernicus Marine Data
+
+The CopernicusMarine package provides access to a wealth of oceanographic data:
+
+- **Physical reanalysis**: Temperature, salinity, currents
+- **Biogeochemical**: Nutrients, chlorophyll, oxygen
+- **Multiple depths**: Surface to bottom
+
+Key functions:
+
+- `cms_products_list()`: Browse available products
+- `cms_product_details()`: Get metadata for a specific product
+- `cms_download_subset()`: Download data for a region and time period
+
+See the [package documentation](https://pepijn-devries.github.io/CopernicusMarine/) for complete usage examples.
+:::
+
+## Linking Trait Data from MOBS
+
+The Marine Organism Body Size (MOBS) database provides body size measurements for marine species, linked via WoRMS AphiaIDs.
+
+### About MOBS
+
+The MOBS database [@mccallum2025] compiles body size data from literature sources, standardised to maximum body length where possible. This makes it ideal for linking to occurrence data that includes WoRMS identifiers.
+
+### Loading MOBS Data
+
+The MOBS database is available from GitHub. We download and filter to species present in our Gulf of Lion occurrence data:
+
+```{r}
+#| label: download-mobs
+#| cache: true
+# Download MOBS database from GitHub
+# The database uses valid_AphiaID and size measurements in cm
+mobs_url <- "https://raw.githubusercontent.com/crmcclain/MOBS_OPEN/main/data_all_112224.csv"
+mobs_raw <- read.csv(mobs_url)
+
+# Preview structure
+names(mobs_raw)
+```
+
+The MOBS database includes body size measurements (length, diameter/width, height) in centimetres. We'll use the length measurement and convert to millimetres for consistency.
+
+```{r}
+#| label: filter-mobs-to-occurrences
+# Get unique AphiaIDs from Gulf of Lion occurrences
+occurrence_aphiaids <- unique(benthos_occurrences$aphiaid)
+
+# Filter MOBS to matching species and select relevant columns
+# Convert length from cm to mm
+mobs_matched <- mobs_raw |>
+  filter(valid_aphiaID %in% occurrence_aphiaids) |>
+  mutate(MaxLength_mm = length_cm * 10) |>  # Convert cm to mm
+  select(valid_aphiaID, scientificName, MaxLength_mm, phylum, class) |>
+  # Take max length per species if multiple records
+  group_by(valid_aphiaID, scientificName, phylum, class) |>
+  summarise(MaxLength_mm = max(MaxLength_mm, na.rm = TRUE), .groups = "drop") |>
+  filter(!is.na(MaxLength_mm), is.finite(MaxLength_mm))
+
+# How many species matched?
+n_matched <- nrow(mobs_matched)
+n_total <- length(occurrence_aphiaids)
+
+cat(sprintf(
+  "Matched %d of %d species (%.1f%%) to MOBS body size data\n",
+  n_matched, n_total, 100 * n_matched / n_total
+))
+```
+
+```{r}
+#| label: preview-mobs-matched
+mobs_matched |>
+  arrange(desc(MaxLength_mm)) |>
+  head(15)
+```
+
+### Body Size Distribution
+
+Let's examine the distribution of body sizes among our matched species:
+
+```{r}
+#| label: fig-body-size-distribution
+#| fig-cap: "Distribution of maximum body length for Gulf of Lion benthic species with MOBS data (log scale)"
+
+ggplot(mobs_matched, aes(x = MaxLength_mm)) +
+  geom_histogram(bins = 30, fill = "#0077BE", colour = "white", alpha = 0.7) +
+  scale_x_log10() +
+  labs(
+    title = "Body Size Distribution",
+    subtitle = sprintf("n = %d Gulf of Lion species with MOBS data", nrow(mobs_matched)),
+    x = "Maximum body length (mm, log scale)",
+    y = "Number of species"
+  ) +
+  theme_minimal()
+```
+
+## Spatial Data Integration
+
+Now we integrate all our data sources through spatial operations:
+
+1. **Characterise habitats environmentally**: Extract mean depth and temperature per habitat type
+2. **Join occurrences to habitats**: Assign each species occurrence to a seabed habitat
+3. **Link trait data**: Match species to body size from MOBS
+
+This approach characterises habitats by their environmental conditions rather than extracting values at individual occurrence points, which is more robust given the patchy distribution of occurrence records.
+
+### Ensuring CRS Alignment
+
+First, let's ensure all spatial data use the same coordinate reference system:
+
+```{r}
+#| label: check-crs-alignment
+# Check CRS of each dataset
+st_crs(benthos_occurrences)$input
+st_crs(seabed_habitats)$input
+crs(depth, describe = TRUE)$name
+```
+
+```{r}
+#| label: align-crs
+# Transform all to WGS84 if needed
+if (st_crs(benthos_occurrences) != st_crs(4326)) {
+  benthos_occurrences <- st_transform(benthos_occurrences, 4326)
+}
+
+if (st_crs(seabed_habitats) != st_crs(4326)) {
+  seabed_habitats <- st_transform(seabed_habitats, 4326)
+}
+```
+
+### Characterising Habitats by Environmental Conditions
+
+We extract mean depth and temperature for each habitat type by aggregating raster values across habitat polygons. This gives us a robust environmental characterisation of each habitat class:
+
+```{r}
+#| label: extract-habitat-environment
+# Extract mean depth per habitat type
+# First aggregate habitat polygons by type, then extract
+habitat_types <- seabed_habitats |>
+  st_drop_geometry() |>
+  distinct(eunis2019c, substrate, biozone)
+
+# For efficiency, sample centroids of habitat polygons
+# and extract environmental values
+habitat_centroids <- seabed_habitats |>
+  st_centroid() |>
+  suppressWarnings()
+
+# Extract depth and temperature at centroids
+centroid_coords <- habitat_centroids |>
+  st_coordinates() |>
+  as.data.frame()
+
+habitat_centroids$depth_m <- terra::extract(depth, centroid_coords)$depth_m
+habitat_centroids$bottom_temp_C <- terra::extract(bottom_temp_mean, centroid_coords)$bottom_temp_C
+
+# Summarise environmental conditions by habitat type
+habitat_env_summary <- habitat_centroids |>
+  st_drop_geometry() |>
+  group_by(eunis2019c, substrate, biozone) |>
+  summarise(
+    n_polygons = n(),
+    mean_depth_m = mean(depth_m, na.rm = TRUE),
+    sd_depth_m = sd(depth_m, na.rm = TRUE),
+    mean_temp_C = mean(bottom_temp_C, na.rm = TRUE),
+    sd_temp_C = sd(bottom_temp_C, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  filter(!is.na(mean_depth_m))
+
+habitat_env_summary |>
+  mutate(across(where(is.numeric), ~ round(.x, 1))) |>
+  head(15) |>
+  knitr::kable()
+```
+
+### Spatial Join: Occurrences to Habitats
+
+We use `st_join()` to link species occurrences to habitat polygons. Only points that fall within a mapped habitat polygon receive a habitat classification:
+
+```{r}
+#| label: spatial-join-habitats
+# Join occurrences to habitat polygons
+# Points outside habitat polygons get NA for habitat columns
+occurrences_with_habitat <- benthos_occurrences |>
+  st_join(seabed_habitats, join = st_within)
+
+# Check how many got habitat assignments
+n_with_habitat <- sum(!is.na(occurrences_with_habitat$eunis2019c))
+cat(sprintf(
+  "%d of %d occurrences (%.1f%%) fall within mapped habitat polygons\n",
+  n_with_habitat, nrow(occurrences_with_habitat),
+  100 * n_with_habitat / nrow(occurrences_with_habitat)
+))
+
+# Filter to occurrences with habitat data
+occurrences_in_habitat <- occurrences_with_habitat |>
+  filter(!is.na(eunis2019c))
+
+cat(sprintf(
+  "Retained %d occurrences with habitat assignments for analysis\n",
+  nrow(occurrences_in_habitat)
+))
+```
+
+### Joining Trait Data
+
+We link species to their body size data via AphiaID, and add habitat-level environmental data:
+
+```{r}
+#| label: join-trait-data
+# Join MOBS data to occurrences
+occurrences_complete <- occurrences_in_habitat |>
+  left_join(
+    mobs_matched,
+    by = c("aphiaid" = "valid_aphiaID")
+  ) |>
+  # Add habitat-level environmental data
+  # Join by all grouping columns to avoid duplicates
+  left_join(
+    habitat_env_summary |> select(eunis2019c, substrate, biozone, mean_depth_m, mean_temp_C),
+    by = c("eunis2019c", "substrate", "biozone")
+  )
+
+# Summary of complete records
+occurrences_complete |>
+  st_drop_geometry() |>
+  summarise(
+    total_records = n(),
+    with_habitat = sum(!is.na(eunis2019c)),
+    with_substrate = sum(!is.na(substrate)),
+    with_biozone = sum(!is.na(biozone)),
+    with_body_size = sum(!is.na(MaxLength_mm)),
+    with_env_data = sum(!is.na(mean_depth_m))
+  ) |>
+  knitr::kable()
+```
+
+## Analysing Trait-Environment Relationships
+
+With our integrated dataset, we can explore how body size varies across habitats and environmental gradients.
+
+### Body Size by Habitat Type
+
+```{r}
+#| label: tbl-bodysize-by-habitat
+#| tbl-cap: "Mean body size by seabed habitat type"
+
+habitat_summary <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(eunis2019c), !is.na(MaxLength_mm)) |>
+  group_by(eunis2019c) |>
+  summarise(
+    n_records = n(),
+    n_species = n_distinct(aphiaid),
+    mean_length_mm = mean(MaxLength_mm, na.rm = TRUE),
+    sd_length_mm = sd(MaxLength_mm, na.rm = TRUE),
+    median_length_mm = median(MaxLength_mm, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  filter(n_records >= 10) |>
+  arrange(desc(mean_length_mm))
+
+habitat_summary |>
+  mutate(across(where(is.numeric), ~ round(.x, 1))) |>
+  knitr::kable()
+```
+
+```{r}
+#| label: fig-bodysize-by-habitat
+#| fig-cap: "Body size distribution by seabed habitat type"
+#| fig-height: 7
+
+plot_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(eunis2019c), !is.na(MaxLength_mm)) |>
+  group_by(eunis2019c) |>
+  filter(n() >= 10) |>
+  ungroup()
+
+ggplot(plot_data, aes(x = reorder(eunis2019c, MaxLength_mm, FUN = median), y = MaxLength_mm)) +
+  geom_boxplot(fill = "#0077BE", alpha = 0.5, outlier.size = 0.5) +
+  scale_y_log10() +
+  coord_flip() +
+  labs(
+    title = "Body Size by Habitat Type",
+    x = "Seabed habitat",
+    y = "Maximum body length (mm, log scale)"
+  ) +
+  theme_minimal()
+```
+
+### Body Size by Substrate Type
+
+The spatial join with habitat polygons allows us to examine how body size varies by substrate type - something the embedded EUNIS codes alone cannot reveal.
+
+```{r}
+#| label: tbl-bodysize-by-substrate
+#| tbl-cap: "Mean body size by substrate type"
+
+substrate_summary <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(substrate), !is.na(MaxLength_mm)) |>
+  group_by(substrate) |>
+  summarise(
+    n_records = n(),
+    n_species = n_distinct(aphiaid),
+    mean_length_mm = mean(MaxLength_mm, na.rm = TRUE),
+    sd_length_mm = sd(MaxLength_mm, na.rm = TRUE),
+    median_length_mm = median(MaxLength_mm, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  filter(n_records >= 10) |>
+  arrange(desc(mean_length_mm))
+
+substrate_summary |>
+  mutate(across(where(is.numeric), ~ round(.x, 1))) |>
+  knitr::kable()
+```
+
+```{r}
+#| label: fig-bodysize-by-substrate
+#| fig-cap: "Body size distribution by seabed substrate type"
+#| fig-height: 5
+
+substrate_plot_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(substrate), !is.na(MaxLength_mm)) |>
+  group_by(substrate) |>
+  filter(n() >= 10) |>
+  ungroup()
+
+if (nrow(substrate_plot_data) > 0) {
+  ggplot(substrate_plot_data, aes(x = reorder(substrate, MaxLength_mm, FUN = median), y = MaxLength_mm)) +
+    geom_boxplot(fill = "#8B4513", alpha = 0.6, outlier.size = 0.5) +
+    scale_y_log10() +
+    coord_flip() +
+    labs(
+      title = "Body Size by Substrate Type",
+      x = "Substrate",
+      y = "Maximum body length (mm, log scale)"
+    ) +
+    theme_minimal()
+} else {
+  message("No substrate data available for plotting")
+}
+```
+
+### Body Size by Biozone
+
+Biozones represent the vertical zonation of the seabed (e.g., infralittoral, circalittoral, bathyal), which correlates with light availability, temperature, and pressure.
+
+```{r}
+#| label: tbl-bodysize-by-biozone
+#| tbl-cap: "Mean body size by biozone"
+
+biozone_summary <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(biozone), !is.na(MaxLength_mm)) |>
+  group_by(biozone) |>
+  summarise(
+    n_records = n(),
+    n_species = n_distinct(aphiaid),
+    mean_length_mm = mean(MaxLength_mm, na.rm = TRUE),
+    sd_length_mm = sd(MaxLength_mm, na.rm = TRUE),
+    median_length_mm = median(MaxLength_mm, na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  filter(n_records >= 10) |>
+  arrange(desc(mean_length_mm))
+
+biozone_summary |>
+  mutate(across(where(is.numeric), ~ round(.x, 1))) |>
+  knitr::kable()
+```
+
+```{r}
+#| label: fig-bodysize-by-biozone
+#| fig-cap: "Body size distribution by biozone"
+#| fig-height: 5
+
+biozone_plot_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(biozone), !is.na(MaxLength_mm)) |>
+  group_by(biozone) |>
+  filter(n() >= 10) |>
+  ungroup()
+
+if (nrow(biozone_plot_data) > 0) {
+  ggplot(biozone_plot_data, aes(x = reorder(biozone, MaxLength_mm, FUN = median), y = MaxLength_mm)) +
+    geom_boxplot(fill = "#2E8B57", alpha = 0.6, outlier.size = 0.5) +
+    scale_y_log10() +
+    coord_flip() +
+    labs(
+      title = "Body Size by Biozone",
+      x = "Biozone",
+      y = "Maximum body length (mm, log scale)"
+    ) +
+    theme_minimal()
+} else {
+  message("No biozone data available for plotting")
+}
+```
+
+### Body Size Along Habitat Depth Gradient
+
+Using the mean depth of each habitat type, we can examine how body size varies along the depth gradient:
+
+```{r}
+#| label: fig-bodysize-depth
+#| fig-cap: "Relationship between body size and habitat mean depth"
+
+depth_plot_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(mean_depth_m), !is.na(MaxLength_mm), mean_depth_m > 0)
+
+ggplot(depth_plot_data, aes(x = mean_depth_m, y = MaxLength_mm)) +
+  geom_point(alpha = 0.2, size = 1, colour = "#0077BE") +
+  geom_smooth(method = "loess", colour = "darkred", fill = "pink", alpha = 0.3) +
+  scale_y_log10() +
+  labs(
+    title = "Body Size vs Habitat Depth",
+    x = "Mean habitat depth (m)",
+    y = "Maximum body length (mm, log scale)"
+  ) +
+  theme_minimal()
+```
+
+### Habitat Depth Distribution
+
+```{r}
+#| label: fig-depth-by-habitat
+#| fig-cap: "Mean depth of habitat types where species occur"
+#| fig-height: 6
+
+habitat_depth_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(eunis2019c), !is.na(mean_depth_m)) |>
+  group_by(eunis2019c) |>
+  filter(n() >= 10) |>
+  ungroup()
+
+ggplot(habitat_depth_data, aes(x = reorder(eunis2019c, mean_depth_m, FUN = median, na.rm = TRUE), y = mean_depth_m)) +
+  geom_boxplot(fill = "#228B22", alpha = 0.5) +
+  coord_flip() +
+  labs(
+    title = "Depth Distribution by Habitat Type",
+    x = "Seabed habitat",
+    y = "Mean habitat depth (m)"
+  ) +
+  theme_minimal()
+```
+
+### Body Size Along Habitat Temperature Gradient
+
+```{r}
+#| label: fig-bodysize-temperature
+#| fig-cap: "Relationship between body size and habitat mean bottom temperature"
+
+temp_plot_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(mean_temp_C), !is.na(MaxLength_mm))
+
+ggplot(temp_plot_data, aes(x = mean_temp_C, y = MaxLength_mm)) +
+  geom_point(alpha = 0.2, size = 1, colour = "#E74C3C") +
+  geom_smooth(method = "loess", colour = "darkblue", fill = "lightblue", alpha = 0.3) +
+  scale_y_log10() +
+  labs(
+    title = "Body Size vs Habitat Temperature",
+    x = "Mean habitat bottom temperature (°C)",
+    y = "Maximum body length (mm, log scale)"
+  ) +
+  theme_minimal()
+```
+
+### Body Size-Environment Interactions by Habitat Type
+
+To explore whether body size-environment relationships differ across habitat types, we create two-panel plots comparing the overall trend with habitat-specific patterns. We focus on habitats with sufficient data (at least 20 occurrences with body size data):
+
+```{r}
+#| label: fig-bodysize-depth-habitat
+#| fig-cap: "Body size vs depth: overall trend (left) compared with habitat-specific patterns (right)"
+#| fig-height: 5
+#| fig-width: 12
+
+# Filter to habitats with enough data for reliable trends
+depth_habitat_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(mean_depth_m), !is.na(MaxLength_mm), !is.na(eunis2019c), mean_depth_m > 0) |>
+  group_by(eunis2019c) |>
+  filter(n() >= 20) |>
+  ungroup()
+
+# Panel A: Overall trend
+p_depth_overall <- ggplot(depth_habitat_data, aes(x = mean_depth_m, y = MaxLength_mm)) +
+  geom_point(alpha = 0.3, size = 1, colour = "grey40") +
+  geom_smooth(method = "loess", colour = "black", fill = "grey70", linewidth = 1.5) +
+  scale_y_log10() +
+  labs(
+    title = "A) Overall trend",
+    x = "Mean habitat depth (m)",
+    y = "Maximum body length (mm)"
+  ) +
+  theme_minimal()
+
+# Panel B: By habitat type
+p_depth_habitat <- ggplot(depth_habitat_data, aes(x = mean_depth_m, y = MaxLength_mm, colour = eunis2019c)) +
+  geom_point(alpha = 0.4, size = 1.5) +
+  geom_smooth(method = "loess", se = FALSE, linewidth = 1.2) +
+  scale_y_log10() +
+  scale_colour_viridis_d(option = "turbo", name = "Habitat") +
+  labs(
+    title = "B) By habitat type",
+    x = "Mean habitat depth (m)",
+    y = NULL
+  ) +
+  theme_minimal() +
+  theme(legend.position = "bottom") +
+  guides(colour = guide_legend(nrow = 3, override.aes = list(size = 3)))
+
+p_depth_overall + p_depth_habitat
+```
+
+```{r}
+#| label: fig-bodysize-temp-habitat
+#| fig-cap: "Body size vs temperature: overall trend (left) compared with habitat-specific patterns (right)"
+#| fig-height: 5
+#| fig-width: 12
+
+# Filter to habitats with enough data
+temp_habitat_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(mean_temp_C), !is.na(MaxLength_mm), !is.na(eunis2019c)) |>
+  group_by(eunis2019c) |>
+  filter(n() >= 20) |>
+
+  ungroup()
+
+# Panel A: Overall trend
+p_temp_overall <- ggplot(temp_habitat_data, aes(x = mean_temp_C, y = MaxLength_mm)) +
+  geom_point(alpha = 0.3, size = 1, colour = "grey40") +
+  geom_smooth(method = "loess", colour = "black", fill = "grey70", linewidth = 1.5) +
+  scale_y_log10() +
+  labs(
+    title = "A) Overall trend",
+    x = "Mean habitat temperature (°C)",
+    y = "Maximum body length (mm)"
+  ) +
+  theme_minimal()
+
+# Panel B: By habitat type
+p_temp_habitat <- ggplot(temp_habitat_data, aes(x = mean_temp_C, y = MaxLength_mm, colour = eunis2019c)) +
+  geom_point(alpha = 0.4, size = 1.5) +
+  geom_smooth(method = "loess", se = FALSE, linewidth = 1.2) +
+  scale_y_log10() +
+  scale_colour_viridis_d(option = "turbo", name = "Habitat") +
+  labs(
+    title = "B) By habitat type",
+    x = "Mean habitat temperature (°C)",
+    y = NULL
+  ) +
+  theme_minimal() +
+  theme(legend.position = "bottom") +
+  guides(colour = guide_legend(nrow = 3, override.aes = list(size = 3)))
+
+p_temp_overall + p_temp_habitat
+```
+
+```{r}
+#| label: fig-bodysize-habitat-facet
+#| fig-cap: "Body size distributions across habitat types, ordered by median body size"
+#| fig-height: 8
+#| fig-width: 10
+
+facet_data <- occurrences_complete |>
+  st_drop_geometry() |>
+  filter(!is.na(MaxLength_mm), !is.na(eunis2019c)) |>
+  group_by(eunis2019c) |>
+  filter(n() >= 10) |>
+  ungroup()
+
+# Calculate median for ordering
+habitat_order <- facet_data |>
+  group_by(eunis2019c) |>
+  summarise(median_size = median(MaxLength_mm, na.rm = TRUE)) |>
+  arrange(median_size) |>
+  pull(eunis2019c)
+
+facet_data <- facet_data |>
+  mutate(eunis2019c = factor(eunis2019c, levels = habitat_order))
+
+ggplot(facet_data, aes(x = eunis2019c, y = MaxLength_mm, fill = eunis2019c)) +
+  geom_boxplot(alpha = 0.7, outlier.size = 0.5) +
+  scale_y_log10() +
+  scale_fill_viridis_d(option = "turbo") +
+  labs(
+    title = "Body Size Distribution by Habitat Type",
+    x = "EUNIS habitat type",
+    y = "Maximum body length (mm, log scale)"
+  ) +
+  theme_minimal() +
+  theme(
+    axis.text.x = element_text(angle = 45, hjust = 1),
+    legend.position = "none"
+  ) +
+  coord_flip()
+```
+
+## Interactive Map
+
+Let's create an interactive map showing species occurrences coloured by body size class, overlaid on seabed habitats:
+
+```{r}
+#| label: create-bodysize-classes
+# Create body size classes for visualisation
+occurrences_for_map <- occurrences_complete |>
+  filter(!is.na(MaxLength_mm)) |>
+  mutate(
+    size_class = cut(
+      MaxLength_mm,
+      breaks = c(0, 10, 50, 200, 1000, Inf),
+      labels = c("<10mm", "10-50mm", "50-200mm", "200-1000mm", ">1000mm"),
+      right = FALSE
+    )
+  )
+```
+
+```{r}
+#| label: fig-interactive-map
+#| eval: false
+
+tmap_mode("view")
+
+tm_shape(seabed_habitats) +
+  tm_polygons(
+    fill = "eunis2019c",
+    fill.scale = tm_scale_categorical(values = "Set3"),
+    fill.legend = tm_legend(title = "EUNIS Habitat"),
+    fill_alpha = 0.5,
+    col_alpha = 0
+  ) +
+  tm_shape(occurrences_for_map) +
+  tm_symbols(
+    fill = "size_class",
+    fill.scale = tm_scale_categorical(values = "viridis"),
+    fill.legend = tm_legend(title = "Body size"),
+    size = 0.1,
+    fill_alpha = 0.7,
+    popup.vars = c(
+      "Species" = "scientificname",
+      "Body length (mm)" = "MaxLength_mm",
+      "Habitat" = "eunis2019c",
+      "Substrate" = "substrate",
+      "Biozone" = "biozone"
+    )
+  )
+```
+
+```{r}
+#| label: fig-interactive-map-render
+#| echo: false
+#| fig-cap: "Benthic species occurrences coloured by body size class in the Gulf of Lion"
+#| fig-height: 8
+
+# Static map version for reliable rendering
+ggplot() +
+  geom_sf(data = med_countries, fill = "gray90", colour = "gray70") +
+  geom_sf(
+    data = occurrences_for_map,
+    aes(colour = size_class),
+    size = 1.5,
+    alpha = 0.6
+  ) +
+  scale_colour_viridis_d(option = "viridis", name = "Body size") +
+  coord_sf(
+    xlim = c(study_bbox["xmin"], study_bbox["xmax"]),
+    ylim = c(study_bbox["ymin"], study_bbox["ymax"])
+  ) +
+  labs(
+    title = "Body Size Distribution Across the Gulf of Lion",
+    subtitle = sprintf("n = %d occurrences with trait data", nrow(occurrences_for_map))
+  ) +
+  theme_minimal() +
+  theme(legend.position = "bottom")
+```
+
+## Discussion
+
+### Key Findings
+
+This analysis demonstrates the integration of multiple EU marine data infrastructures to explore trait-environment relationships:
+
+1. **Habitat associations**: Different seabed habitats support benthic communities with distinct body size distributions
+2. **Environmental gradients**: Body size shows variation along both depth and temperature gradients
+3. **Data integration**: Linking occurrence data to external trait databases and environmental layers substantially enriches analytical potential
+
+### Ecological Interpretation
+
+The observed patterns may reflect several ecological processes:
+
+- **Environmental filtering**: Physical conditions in different habitats may favour certain body sizes
+- **Resource availability**: Habitat productivity and food supply influence what body sizes can be sustained
+- **Predation pressure**: Different habitats offer varying levels of refuge, potentially affecting body size distributions
+
+However, these interpretations require caution:
+
+1. **Sampling bias**: Occurrence records may not represent true community composition
+2. **Taxonomic coverage**: MOBS trait data is incomplete, with smaller and less-studied taxa underrepresented
+3. **Spatial mismatch**: Environmental data resolution may not capture fine-scale heterogeneity
+
+### Limitations
+
+- **Trait coverage**: Not all species in the occurrence data have body size records in MOBS
+- **Temporal mismatch**: Occurrence records span different time periods than environmental data
+- **Single trait focus**: Body size is just one dimension of functional diversity
+
+### Extensions
+
+This workflow could be extended to:
+
+- Include additional traits (feeding mode, mobility, reproduction strategy)
+- Analyse temporal trends in trait composition
+- Model trait-environment relationships more formally
+- Compare patterns across regions
+
+## What You've Learned
+
+This tutorial demonstrated advanced multi-source integration:
+
+- **EMODnet WFS**: Accessing occurrence records and habitat polygons
+- **EMODnet WCS**: Retrieving bathymetry rasters
+- **Copernicus Marine Service**: Downloading oceanographic data
+- **External databases**: Linking to trait data via taxonomic identifiers
+- **Spatial operations**: Joins, extractions, and alignments across data types
+- **Trait-based analysis**: Exploring functional diversity across habitats
+
+These skills enable complex marine ecological analyses that draw on the full breadth of available EU marine data.
+
+## Further Resources
+
+- [EMODnet Biology Portal](https://emodnet.ec.europa.eu/en/biology): Species occurrence data
+- [EMODnet Seabed Habitats Portal](https://emodnet.ec.europa.eu/en/seabed-habitats): Habitat maps
+- [Copernicus Marine Service](https://marine.copernicus.eu/): Oceanographic data
+- [World Register of Marine Species (WoRMS)](https://www.marinespecies.org/): Taxonomic backbone
+- [MOBS Database](https://github.com/crmcclain/MOBS_OPEN): Marine body size data
+
+## References

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -892,6 +892,9 @@ Each yearly time step is a 2D spatial grid (longitude × latitude), and the full
 ```{r}
 #| label: inspect-stars-time
 time_vals <- stars::st_get_dimension_values(bottom_temp_stars, "time")
+# Ensure consistent POSIXct format (stars may use different time
+# reference systems depending on the data source and platform)
+time_vals <- as.POSIXct(time_vals)
 cat("Time steps:", length(time_vals))
 cat("First:", format(time_vals[1]))
 cat("Last:", format(time_vals[length(time_vals)]))

--- a/tutorials/tutorial-04.qmd
+++ b/tutorials/tutorial-04.qmd
@@ -1317,7 +1317,7 @@ biozone_plot_data <- benthos_joined |>
 
 ggplot(
   biozone_plot_data,
-  aes(x = max_body_size_mm, y = fct_rev(biozone))
+  aes(x = max_body_size_mm, y = factor(biozone, levels = rev(levels(biozone))))
 ) +
   geom_density_ridges_gradient(
     aes(fill = after_stat(x)),


### PR DESCRIPTION
## Summary

Closes #11

Adds Tutorial 4, which demonstrates multi-source marine data integration by combining EMODnet WFS (habitat polygons, species occurrences), EMODnet WCS (bathymetry), Copernicus Marine Service (bottom temperature), and the MOBS body size database to characterise benthic biozones in the Gulf of Lion.

## Deviations from the original plan

The [original issue](https://github.com/r-rse/emodnet-bio-r-geo-tutorials/issues/11) proposed exploring trait-environment relationships across seabed habitats in the Aegean Sea. The implementation diverges in two key ways:

**Study area: Gulf of Lion instead of Aegean Sea.** The Aegean had limited spatial variability for this analysis (only 77 unique sampling locations, 80% sandy mud substrate). The Gulf of Lion offers ~16,700 occurrence records across 1,173 species and 163 unique locations with diverse substrates.

**Narrative focus: biozone characterisation instead of trait-environment correlations.** The data showed no meaningful body size correlation with depth or temperature (narrow temperature range of ~13-15.5C, most occurrences concentrated at 0-100m depth). Rather than forcing a non-existent relationship, the tutorial reframes around characterising each biozone (infralittoral through abyssal) using habitat composition, substrate type, environmental conditions, and body size distributions. This keeps all data sources justified while telling a coherent ecological story.

## Key technical features

- **Spatial joins** (`sf::st_join`) to link occurrences to habitat polygons by geographic location, rather than joining on pre-matched EUNIS codes (which would duplicate records across unrelated polygons)
- **CQL attribute filtering** (new to the tutorial series) to clean habitat data server-side
- **Zonal statistics** with `terra::extract()` in an equal-area projection (EPSG:3035)
- **Copernicus Marine Service** integration via `CopernicusMarine` package, using yearly temperature data subset to sampling years
- **Interactive leaflet map** (replacing tmap, which used WebGL rendering that caused polygon tessellation artifacts) with `smoothFactor = 0` and HTML popups
- **`pmax()`** across MOBS length/diameter/height columns to maximise species coverage

## Known workaround

The `timerange` parameter in `cms_download_subset()` is currently commented out due to an [upstream bug](https://github.com/pepijn-devries/CopernicusMarine/issues/164) with time dimension handling. As a workaround, we download all available years and filter to sampled years in R. The `timerange` will be restored once the fix is released. The tutorial text is left as-is since it describes the intended behaviour. See the PR comments below for details on the investigation.

## Other changes

- Fix broken MSFD URL in tutorial-01
- Fix broken EUSeaMap URL in tutorial-04
- Add `.lycheeignore` for DOI resolver 403 false positives
- Add `leaflet` and `htmlwidgets` to DESCRIPTION
- Update `index.qmd` and `_quarto.yml` for tutorial 4 entry

## Test plan

- [ ] Full clean render (`rm -rf tutorials/tutorial-04_cache && quarto render`)
- [ ] Verify interactive leaflet map renders without polygon artifacts
- [ ] Review rendered output for plot quality and prose accuracy