### PR TITLE
Post-transfer cleanup: lychee + README status/DOI

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,13 +1,2 @@
 # DOI resolvers often block automated link checkers with 403
 https://doi.org/.*
-
-# Forward-looking EMODnet URLs.
-# The repo and rendered site still live at r-rse/* until the planned
-# transfer to the EMODnet GitHub org. Until then, every link to
-# github.com/EMODnet/emodnet-bio-r-geo-tutorials and to the future
-# emodnet.github.io site (workflow badges, repo-url, edit/issue links,
-# CITATION.cff, README, about page, etc.) will 404.
-# Tracked in https://github.com/r-rse/emodnet-bio-r-geo-tutorials/issues/45
-# Remove these entries once the repo is transferred.
-https://github.com/EMODnet/emodnet-bio-r-geo-tutorials.*
-https://emodnet.github.io/emodnet-bio-r-geo-tutorials.*

--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ Krystalli, A. (2025). EMODnet Biology R Geospatial Tutorials [Data set].
 https://github.com/EMODnet/emodnet-bio-r-geo-tutorials
 ```
 
-_Note: A DOI will be added once the tutorials are archived on Zenodo._
-
 ## Links
 
 -   **EMODnet:** [emodnet.eu](https://emodnet.eu)
@@ -204,7 +202,3 @@ Copyright © 2025 European Climate, Infrastructure and Environment Executive Age
 ### Reviewers
 
 Thanks to Maëlle Salmon ([@maelle](https://github.com/maelle)) and Joana Beja ([@JoBeja](https://github.com/JoBeja)) for thorough review of the tutorials and supporting documentation.
-
-------------------------------------------------------------------------
-
-**Status:** This project is in active development. Tutorials and documentation are being added incrementally.


### PR DESCRIPTION
## Lychee ignore (closes #45)

Now that the repo is at EMODnet/* and the Pages site is live, every URL we broadened the lychee ignore for in #52 resolves. Verified by curl:

- github.com/EMODnet/emodnet-bio-r-geo-tutorials → 200
- github.com/EMODnet/emodnet-bio-r-geo-tutorials/issues → 200
- github.com/EMODnet/emodnet-bio-r-geo-tutorials/edit/main/index.qmd → 302 (auth redirect, fine)
- emodnet.github.io/emodnet-bio-r-geo-tutorials/ → 200

Drop the EMODnet patterns; keep only the doi.org regex which still 403s.

## README cleanup

Drop the trailing "Status: This project is in active development..." footer and the "_Note: A DOI will be added once..._" placeholder. Project is past early development; all four tutorials are live. DOI line can come back when the Zenodo deposit happens.